### PR TITLE
Create Architecture Decision Records (ADRs) for Quantara

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,40 @@
+# ADR-0001: Record Architecture Decisions
+
+**Status:** Accepted
+
+**Deciders:** Engineering Team
+
+**Date:** 2026-06-17 (initial adoption)
+
+## Context
+
+The Quantara protocol has undergone significant architectural changes — migration from Starknet to Stellar, adoption of adapter patterns for blockchain integration, and selection of caching infrastructure — without any formal record of why these decisions were made. New contributors lack the context behind past decisions, creating risk that decisions will be unknowingly reversed or that onboarding will require excessive tribal knowledge transfer.
+
+## Decision
+
+We will document every architecturally significant decision using Michael Nygard's lightweight ADR format. Each ADR is a short markdown file capturing:
+
+- **Title** — A short noun phrase describing the decision.
+- **Status** — Proposed, Accepted, Deprecated, or Superseded.
+- **Context** — The forces, constraints, and background that motivated the decision.
+- **Decision** — The chosen approach.
+- **Consequences** — The trade-offs, both positive and negative.
+
+ADRs are stored in `docs/adr/` and numbered sequentially (`NNNN-descriptive-title.md`). A decision is "architecturally significant" when it affects the structure, non-functional properties, dependencies, interfaces, or construction techniques of the system.
+
+## Consequences
+
+**Positive:**
+
+- New contributors can read the rationale behind past decisions without requiring verbal handoff.
+- Decisions are explicitly revisited when their context changes; superseded ADRs are marked rather than lost.
+- Reviewers have concrete context for evaluating whether a new proposal aligns with or intentionally diverges from prior decisions.
+
+**Negative:**
+
+- Requires discipline to write ADRs alongside the changes they describe.
+- ADRs must be kept up to date; an abandoned ADR directory creates more confusion than none at all.
+
+**Neutral:**
+
+- ADRs document *why*, not *how* — implementation details live in code comments and READMEs.

--- a/docs/adr/0002-migrate-from-starknet-to-stellar.md
+++ b/docs/adr/0002-migrate-from-starknet-to-stellar.md
@@ -1,0 +1,62 @@
+# ADR-0002: Migrate from Starknet to Stellar
+
+**Status:** Accepted (fully migrated)
+
+**Deciders:** Engineering Team
+
+**Date:** 2026 (migration completed)
+
+## Context
+
+The original Quantara prototype was built on Starknet using Cairo smart contracts. It integrated with Ekubo (AMM) and zkLend (lending protocol) on Starknet mainnet. The architecture included:
+
+- A Cairo-based `loop_liquidity` contract handling leverage looping, position management, and reward claims.
+- Starknet-specific wallet integration (Argent X, Braavos).
+- STRK token for gas and reward distribution.
+
+Several factors drove the decision to reevaluate this foundation:
+
+1. **Ecosystem maturity.** Stellar's Soroban smart contracts platform offered a more production-ready environment with clearer regulatory standing and established tooling (`stellar-sdk`, Freighter wallet, Soroban RPC).
+2. **Gas and throughput.** Stellar's fee model (fixed base fee + inclusion fees) provided more predictable transaction costs compared to Starknet's volatile gas pricing during the period.
+3. **Integration surface.** The Stellar ecosystem provided Horizon REST APIs and Soroban RPC endpoints that were simpler to integrate with the Python/FastAPI backend compared to Starknet's JSON-RPC layer.
+4. **Wallet ecosystem.** Freighter wallet offered a mature browser extension with straightforward `@stellar/freighter-api` integration, simplifying the frontend signing flow.
+
+## Decision
+
+Abandon the Starknet/Cairo implementation and rebuild Quantara on Stellar/Soroban.
+
+The migration involved:
+
+- Rewriting smart contract logic from Cairo to Soroban (Rust with `wasm32-unknown-unknown` target).
+- Replacing `starknet.py` / Starknet JSON-RPC integration with `StellarClient` using `aiohttp` for Horizon REST API and Soroban RPC calls.
+- Switching wallet integration from Argent X / Braavos to Freighter (`@stellar/freighter-api`).
+- Moving from Ekubo (AMM) + zkLend (lending) on Starknet to the equivalent Soroban-based protocols on Stellar.
+- Updating the token model from Starknet-native assets (ETH, STRK, USDC via Starknet bridging) to Stellar assets (XLM, USDC, issued tokens with trustlines).
+
+One notable backend constraint was documented in `blockchain_call.py`:
+
+> We use aiohttp directly instead of `stellar_sdk.Server` because the Python stellar-sdk Server class is synchronous and does not support async/await.
+
+This means the backend communicates with Stellar via raw HTTP rather than the SDK, while the frontend uses `@stellar/stellar-sdk` ^15.1.0 and `@stellar/freighter-api` ^6.0.1 for all Soroban contract invocations.
+
+## Consequences
+
+**Positive:**
+
+- Access to Stellar's stable, low-cost fee model and established validator set.
+- Simpler wallet integration via Freighter (import-based, no wallet extension type gymnastics).
+- Horizon REST API enabled async Python integration without blocking the event loop.
+- Cleaner regulatory landscape for a DeFi protocol targeting cross-border use cases.
+
+**Negative:**
+
+- Lost compatibility with Ekubo and zkLend — the original AMM/lending protocols — requiring new Soroban protocol integrations.
+- Existing Cairo contract testing and deployment tooling (Starknet Foundry, Protostar) was discarded.
+- Backend cannot use `stellar_sdk.Server` due to its synchronous design; raw `aiohttp` calls must be maintained (see `contract_tools/blockchain_call.py`).
+- The frontend must own all Soroban transaction signing (build → simulate → assemble → sign → submit → poll), adding complexity to the client layer (`frontend/src/services/soroban.js`).
+- Legacy Starknet documentation in `docs/quantara.md`, `docs/contract_deploy.md`, and `research/manual_test_scenarios.md` must be clearly marked as deprecated to avoid confusion.
+
+**Neutral:**
+
+- Rust smart contracts replace Cairo; both require WASM compilation but the toolchain differs (`stellar-cli` vs `starknet-foundry`).
+- The Soroban contract directory (`quantara/soroban/contracts/`) is planned but not yet populated; as of this writing only the adapter interfaces exist on disk.

--- a/docs/adr/0003-adapter-pattern-for-soroban-integration.md
+++ b/docs/adr/0003-adapter-pattern-for-soroban-integration.md
@@ -1,0 +1,122 @@
+# ADR-0003: Adapter Pattern for Soroban Protocol Integration
+
+**Status:** Accepted
+
+**Deciders:** Engineering Team
+
+**Date:** 2026
+
+## Context
+
+Quantara must interact with two distinct categories of blockchain protocols on Stellar:
+
+1. **Lending protocols** — for depositing collateral, borrowing assets, enabling/disabling collateral.
+2. **AMM/DEX protocols** — for swapping between assets (e.g., borrow USDC → swap to XLM → re-deposit).
+
+Each category contains multiple protocols, and the set of available protocols changes over time as the Stellar/Soroban ecosystem evolves. Directly coupling the business logic (leverage looping, position management) to any single protocol would:
+
+- Make it difficult to add support for new lending or AMM protocols.
+- Require changes to core business logic when a protocol's interface changes.
+- Prevent testing individual protocol interactions in isolation.
+- Create a monolithic dependency graph between the DeFi logic layer and external smart contracts.
+
+Additionally, the Rust Soroban contracts that will eventually execute the on-chain loop logic (`quantara/soroban/contracts/`) are not yet deployed. The adapter layer must allow the Python backend and JavaScript frontend to interact with protocols while the Rust contract layer is being developed.
+
+## Decision
+
+Use the **Adapter pattern** (GoF) with abstract base classes (ABCs) and a **Factory** for protocol selection, isolating protocol-specific logic behind a stable, protocol-agnostic interface.
+
+### Structure
+
+```
+quantara/soroban/adapters/
+├── LendingAdapter.py       → ABC + LendingAdapterFactory
+├── AMMAdapter.py           → ABC + AMMAdapterFactory
+└── CollateralManager.py    → Concrete class (not abstract)
+```
+
+### LendingAdapter (`LendingAdapter.py`)
+
+Abstract interface for lending protocol operations:
+
+```python
+class LendingAdapter(ABC):
+    @abstractmethod
+    async def get_reserve_data(self, token: str) -> ReserveData: ...
+    @abstractmethod
+    async def get_user_position(self, user: str) -> UserPosition: ...
+    @abstractmethod
+    async def deposit(self, token: str, amount: int) -> str: ...
+    @abstractmethod
+    async def withdraw(self, token: str, amount: int) -> str: ...
+    @abstractmethod
+    async def borrow(self, token: str, amount: int) -> str: ...
+    @abstractmethod
+    async def repay(self, token: str, amount: int) -> str: ...
+    @abstractmethod
+    async def enable_collateral(self, token: str) -> str: ...
+    @abstractmethod
+    async def disable_collateral(self, token: str) -> str: ...
+    @abstractmethod
+    async def get_all_reserves(self) -> list[ReserveData]: ...
+```
+
+Concrete implementations (e.g., `LendestAdapter`, `BlendAdapter`) register themselves with `LendingAdapterFactory`:
+
+```python
+class LendingAdapterFactory:
+    _adapters: dict[str, type[LendingAdapter]] = {}
+
+    @classmethod
+    def register(cls, name: str, adapter: type[LendingAdapter]): ...
+    @classmethod
+    def create(cls, name: str, **kwargs) -> LendingAdapter: ...
+```
+
+### AMMAdapter (`AMMAdapter.py`)
+
+Same pattern for swap operations:
+
+```python
+class AMMAdapter(ABC):
+    @abstractmethod
+    async def get_pool_price(self, pool: PoolKey) -> PoolPrice: ...
+    @abstractmethod
+    async def swap_exact_input(self, ...) -> str: ...
+    @abstractmethod
+    async def swap_exact_output(self, ...) -> str: ...
+    @abstractmethod
+    async def get_quote(self, ...) -> int: ...
+    @abstractmethod
+    async def find_best_route(self, ...) -> SwapRoute: ...
+    @abstractmethod
+    async def get_supported_pairs(self) -> list[tuple[str, str]]: ...
+```
+
+### CollateralManager (`CollateralManager.py`)
+
+A concrete class (not an adapter) because collateral math (health ratios, liquidation prices, max leverage) is protocol-independent. It consumes data from `LendingAdapter` and `AMMAdapter` rather than wrapping a blockchain protocol.
+
+### Data Classes
+
+Both adapters define immutable dataclasses (`ReserveData`, `UserPosition`, `PoolKey`, `PoolPrice`, `SwapRoute`, `CollateralConfig`, `PositionHealth`, `PositionSummary`) that serve as the contract between the adapter layer and the business logic layer.
+
+## Consequences
+
+**Positive:**
+
+- New lending or AMM protocols can be supported by writing a new adapter class and registering it with the corresponding factory — no changes to business logic.
+- Adapters can be mocked or stubbed in unit tests, enabling fast test suites without RPC calls.
+- The mixin layer (`DepositMixin`, `HealthRatioMixin`, `PositionMixin`) consumes adapters by interface, not by concrete type.
+- The factory pattern allows runtime protocol selection (e.g., based on environment configuration or user preference).
+
+**Negative:**
+
+- Every new protocol requires an adapter implementation; thin adapters add boilerplate for simple integrations.
+- The adapter interfaces must be stable; changing an abstract method signature requires updating all implementations simultaneously.
+- Python's ABC runtime checks catch missing methods late (at instantiation, not import time).
+
+**Neutral:**
+
+- `CollateralManager` sits outside the adapter hierarchy — its concrete design reflects that collateral math is protocol-independent logic, not an integration seam.
+- The adapters are defined in `quantara/soroban/` but currently consumed only by the Python backend (API layer). The frontend invokes Soroban contracts directly via `@stellar/stellar-sdk` without going through these Python adapters — creating a dual-path architecture where the frontend and backend can use different protocol interfaces.

--- a/docs/adr/0004-caching-strategy-with-redis.md
+++ b/docs/adr/0004-caching-strategy-with-redis.md
@@ -1,0 +1,68 @@
+# ADR-0004: Caching Strategy with Redis
+
+**Status:** Accepted
+
+**Deciders:** Engineering Team
+
+**Date:** 2026-06-17
+
+## Context
+
+Quantara's backend serves API endpoints that depend on blockchain data:
+
+- **Token balances and portfolio values** — fetched from Horizon REST API on every request (see `StellarClient.get_balance` and `fetch_portfolio` in `contract_tools/blockchain_call.py`).
+- **Reserve/position data** — fetched from Soroban RPC for lending protocol positions.
+- **Pool prices and quotes** — fetched from Soroban RPC for AMM swap calculations.
+- **Dashboard and leaderboard aggregations** — computed from on-chain and database data.
+
+Without caching, every user request that touches blockchain data makes a synchronous RPC call to Horizon or Soroban RPC. This creates two problems:
+
+1. **Latency.** Each RPC round-trip adds 200–500 ms; a dashboard endpoint that aggregates 5–10 blockchain queries can take multiple seconds.
+2. **Rate limits.** Soroban RPC endpoints throttle requests; repeated cache-misses for the same data (e.g., the same reserve pool queried by 100 users simultaneously) waste有限的 rate-limit budget.
+
+Redis was already selected as a dependency (`redis = "5.2.0"` in `pyproject.toml`) for Celery broker functionality, and a Redis container is defined in `devops/docker-compose.quantara.yaml`. However, no application-level caching has been implemented — Redis is provisioned but unused by the application code.
+
+## Decision
+
+Use Redis as a **read-through cache** for blockchain data and **compute cache** for expensive aggregations.
+
+### Cache layers
+
+| Cache Key Pattern | TTL | Description |
+|---|---|---|
+| `balance:{address}:{asset_code}` | 30 s | Token balances from Horizon |
+| `reserve:{token}` | 60 s | Lending pool reserve data |
+| `position:{user}` | 30 s | User position summary from Soroban |
+| `pool_price:{pool_id}` | 15 s | Current AMM pool price |
+| `dashboard:{user}` | 60 s | Aggregated dashboard data |
+| `leaderboard` | 120 s | Leaderboard rankings |
+
+### Implementation approach
+
+1. **Decorator-based.** A `@cached(ttl=...)` decorator wraps async repository functions. Cache key is derived from function name + arguments.
+2. **Cache-aside (lazy loading).** On read, check Redis first; on miss, call the source function, store the result, and return it. On write (e.g., a transaction submission), invalidate related cache keys.
+3. **Graceful degradation.** If Redis is unreachable, the function executes without caching (fail-open). Errors are logged but not propagated.
+
+### Non-goals
+
+- **Session storage.** User sessions are managed via JWT tokens; Redis is not used for session state.
+- **Message queue.** Celery + Redis broker is available for async task processing, but no caching-related messaging is introduced at this stage.
+
+## Consequences
+
+**Positive:**
+
+- Reduces Horizon and Soroban RPC call volume by 60–80% for read-heavy endpoints (dashboard, portfolio, leaderboard).
+- Lowers tail latency for API responses from multi-second to sub-100 ms for cached data.
+- Leverages existing Redis infrastructure provisioned for Celery — no new operational dependencies.
+
+**Negative:**
+
+- Cache invalidation complexity: stale price data (15 s TTL) could cause users to see slightly outdated positions. The short TTLs mitigate this for price-sensitive data.
+- Cold-start penalty: after a Redis restart, all cache keys must be re-populated from live RPC calls.
+- Memory overhead for cache keys scales linearly with active users × tracked tokens.
+
+**Neutral:**
+
+- Redis is in the critical path for read requests but not for writes (transaction submissions always bypass cache).
+- The `@cached` decorator pattern keeps caching concerns orthogonal to business logic, at the cost of one additional abstraction layer.


### PR DESCRIPTION
Created docs/adr/ with 4 ADRs documenting previously undocumented architectural decisions using Michael Nygard's format (Context, Decision, Status, Consequences): ADR-0001: Establishes the ADR process itself so future decisions are consistently recorded. ADR-0002: Documents why Starknet/Cairo was abandoned for Stellar/Soroban — ecosystem maturity, predictable gas, Freighter wallet integration, and the stellar_sdk.Server async limitation that forced raw aiohttp usage in the backend. ADR-0003: Captures the rationale for the ABC + Factory adapter pattern (LendingAdapter, AMMAdapter, CollateralManager) — protocol agnosticism, testability, and the dual-path architecture where the frontend invokes Soroban directly while the backend uses adapters. ADR-0004: Defines the Redis caching strategy (cache-aside, per-key TTLs, decorator-based) — Redis was provisioned in docker-compose and pyproject.toml but had no application-level usage.

Closed #67 