### PR TITLE
ci: add Dependabot configuration and patch auto-merge workflow #72

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Python / Poetry Dependencies
+  - package-ecosystem: "pip"
+    directory: "/quantara"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # React / Yarn Dependencies
+  - package-ecosystem: "npm"
+    directory: "/quantara/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Docker Dependencies
+  - package-ecosystem: "docker"
+    directory: "/quantara"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions Dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
 
   # React / Yarn Dependencies
   - package-ecosystem: "npm"
-    directory: "/quantara/frontend"
+    directory: "/quantara/frontend" # Updated to reflect nested structure
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -23,7 +23,7 @@ updates:
 
   # GitHub Actions Dependencies
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/" # GitHub Actions must remain at the absolute root
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,26 @@
+name: Dependabot Auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Only run this if the PR author is Dependabot
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch updates
+        # Only proceed if it is a patch update. Major and minor will require manual review.
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Description
This PR resolves #72 by introducing an automated dependency management lifecycle for the Quantara monorepo. 

Because the core application modules (`web_app`, `frontend`, and Dockerfiles) are nested inside the `/quantara` subdirectory, the package configurations have been mapped carefully to prevent root-level directory resolution failures.

## Scope of Changes
- **`.github/dependabot.yml`**: Configures weekly checks for Poetry (`pip`) and React (`npm`), alongside monthly schedules for internal Dockerfiles and GitHub Actions. Open PR thresholds are strictly throttled to a maximum of 5 to eliminate notification noise.
- **`.github/workflows/dependabot-automerge.yml`**: A secure automation workflow that fetches Dependabot metadata, validates semantic versioning strings, and instantly triggers squash-merging via the GitHub CLI **only** if the incoming update is a low-risk `semver-patch`. Major and minor upgrades will intentionally skip this loop and halt for manual code review.

## Verification Checklist
- [x] Verified Poetry (`pip`) target directory points to `/quantara`.
- [x] Verified React ecosystem path correctly maps to `/quantara/frontend`.
- [x] Verified Docker ecosystem scans the nested `/quantara` workspace.
- [x] Confirmed GitHub Actions pipeline stays targeted at the repo root (`/`).

*Note for Maintainers: Please verify that "Allow auto-merge" is toggled on under the repository's General settings to ensure the patch workflow successfully executes standard `gh pr merge` hooks.

The auto-merge workflow successfully triggered and skipped on this PR as expected, confirming that the github.actor == 'dependabot[bot]' security guard is functional and will only execute when the actual automated bot opens an update.
*
<img width="1440" height="445" alt="image" src="https://github.com/user-attachments/assets/9cacedb8-2c53-4098-ae97-4d1b16fbcd87" />
