### PR TITLE
Replace module

### DIFF
--- a/quantara/web_app/alembic/env.py
+++ b/quantara/web_app/alembic/env.py
@@ -14,13 +14,13 @@ from sqlalchemy import pool
 
 from alembic import context
 
-from web_app.db.database import SQLALCHEMY_DATABASE_URL
+from web_app.db.database import get_database_url
 from web_app.db.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URL)
+config.set_main_option("sqlalchemy.url", get_database_url())
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/quantara/web_app/api/dashboard.py
+++ b/quantara/web_app/api/dashboard.py
@@ -6,10 +6,12 @@ for the Stellar-based Quantara protocol.
 import collections
 from decimal import Decimal, DivisionByZero
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from web_app.api.serializers.dashboard import DashboardResponse
 from web_app.contract_tools.mixins import DashboardMixin, HealthRatioMixin
+from web_app.api.dependencies import get_stellar_client
+from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.db.crud import PositionDBConnector
 
 router = APIRouter()
@@ -23,7 +25,10 @@ position_db_connector = PositionDBConnector()
     response_model=DashboardResponse,
     response_description="Returns user's balances, multipliers, start dates, and position data.",
 )
-async def get_dashboard(wallet_id: str) -> DashboardResponse:
+async def get_dashboard(
+    wallet_id: str,
+    client: StellarClient = Depends(get_stellar_client)
+) -> DashboardResponse:
     """
     Fetch the user's dashboard data, including balances, multipliers,
     start dates, deposit_data, and health ratio.
@@ -67,7 +72,7 @@ async def get_dashboard(wallet_id: str) -> DashboardResponse:
 
     try:
         health_ratio, tvl = await HealthRatioMixin.get_health_ratio_and_tvl(
-            contract_address
+            contract_address, client
         )
     except (IndexError, DivisionByZero, ZeroDivisionError):
         return default_dashboard_response

--- a/quantara/web_app/api/dependencies.py
+++ b/quantara/web_app/api/dependencies.py
@@ -1,0 +1,11 @@
+"""
+API dependencies for the Quantara FastAPI application.
+"""
+
+from web_app.contract_tools.blockchain_call import StellarClient
+
+def get_stellar_client() -> StellarClient:
+    """
+    FastAPI dependency that returns a StellarClient instance.
+    """
+    return StellarClient()

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -8,12 +8,16 @@ endpoints, and exposes a /health endpoint for CI orchestration.
 
 import logging
 import os
+import asyncio
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response, Depends
 from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+import redis.asyncio as redis
 
 from web_app.api.dashboard import router as dashboard_router
 from web_app.api.position import router as position_router
@@ -23,7 +27,7 @@ from web_app.api.vault import router as vault_router
 from web_app.api.leaderboard import router as leaderboard_router
 from web_app.api.referal import router as referal_router
 from web_app.config_validator import assert_valid_config
-from web_app.db.database import init_db
+from web_app.db.database import init_db, get_database
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +109,38 @@ app.add_middleware(
 
 
 @app.get("/health", tags=["Health"], summary="Health check endpoint")
-async def health_check():
-    """Returns 200 OK when the service is running."""
-    return {"status": "healthy"}
+async def health_check(response: Response, db: Session = Depends(get_database)):
+    """Returns 200 OK when the service is running and dependencies are healthy."""
+    health_status = {"status": "healthy", "database": "up", "redis": "up"}
+    is_healthy = True
+
+    # Check Database
+    try:
+        # Use asyncio.to_thread for synchronous SQLAlchemy call to prevent blocking the event loop
+        await asyncio.wait_for(
+            asyncio.to_thread(db.execute, text("SELECT 1")), timeout=2.0
+        )
+    except Exception as e:
+        logger.error(f"Database health check failed: {e}")
+        health_status["database"] = "down"
+        is_healthy = False
+
+    # Check Redis
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    try:
+        r = redis.from_url(redis_url)
+        await asyncio.wait_for(r.ping(), timeout=2.0)
+        await r.close()
+    except Exception as e:
+        logger.error(f"Redis health check failed: {e}")
+        health_status["redis"] = "down"
+        is_healthy = False
+
+    if not is_healthy:
+        health_status["status"] = "degraded"
+        response.status_code = 503
+
+    return health_status
 
 
 # No startup-time blockchain contract init needed – the frontend

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -8,6 +8,7 @@ endpoints, and exposes a /health endpoint for CI orchestration.
 
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -22,26 +23,37 @@ from web_app.api.vault import router as vault_router
 from web_app.api.leaderboard import router as leaderboard_router
 from web_app.api.referal import router as referal_router
 from web_app.config_validator import assert_valid_config
+from web_app.db.database import init_db
 
 logger = logging.getLogger(__name__)
 
-# Validate required environment variables at startup.
-# In production this raises a clear RuntimeError; in development it
-# only logs warnings about missing optional variables.
-assert_valid_config()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Lifespan context manager for FastAPI.
+    Handles application startup and shutdown events.
+    """
+    init_db()
 
-# Initialize Sentry SDK if in production
-if os.getenv("ENV_VERSION") == "PROD":
-    import sentry_sdk
+    # Validate required environment variables at startup.
+    assert_valid_config()
 
-    sentry_sdk.init(
-        dsn=os.getenv("SENTRY_DSN"),
-        traces_sample_rate=1.0,
-        _experiments={
-            "continuous_profiling_auto_start": True,
-        },
-    )
+    # Enforce minimum length for session secret at startup
+    secret = os.getenv("SESSION_SECRET_KEY")
+    if secret and len(secret) < 32:
+        raise ValueError("SESSION_SECRET_KEY must be at least 32 characters long.")
 
+    # Initialize Sentry SDK if in production
+    if os.getenv("ENV_VERSION") == "PROD":
+        import sentry_sdk
+        sentry_sdk.init(
+            dsn=os.getenv("SENTRY_DSN"),
+            traces_sample_rate=1.0,
+            _experiments={
+                "continuous_profiling_auto_start": True,
+            },
+        )
+    yield
 
 app = FastAPI(
     title="QUANTARA API",
@@ -54,6 +66,7 @@ app = FastAPI(
         "name": "MIT License",
         "url": "https://opensource.org/licenses/MIT",
     },
+    lifespan=lifespan,
 )
 
 
@@ -79,24 +92,9 @@ async def global_exception_handler(request: Request, exc: Exception):
         content={"detail": "Internal server error"},
     )
 
-_SESSION_SECRET_MIN_LENGTH = 32
-_is_production = os.getenv("ENV_VERSION") == "PROD"
-
-_session_secret = os.getenv("SESSION_SECRET_KEY")
-
-if _session_secret:
-    if len(_session_secret) < _SESSION_SECRET_MIN_LENGTH:
-        raise ValueError(
-            f"SESSION_SECRET_KEY must be at least {_SESSION_SECRET_MIN_LENGTH} characters long."
-        )
-elif _is_production:
-    raise ValueError(
-        "SESSION_SECRET_KEY environment variable must be set in production. "
-        "Generate one with: python -c \"import os; print(os.urandom(32).hex())\""
-    )
-else:
-    # Development only: auto-generate a key (sessions won't persist across restarts)
-    _session_secret = os.urandom(32).hex()
+# Fetch at import time for middleware registration, but do not raise exceptions here.
+# Strict validation and missing value errors are handled by assert_valid_config() and lifespan().
+_session_secret = os.getenv("SESSION_SECRET_KEY", os.urandom(32).hex())
 
 # Add session middleware with a persistent secret key
 app.add_middleware(SessionMiddleware, secret_key=_session_secret)

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -5,7 +5,7 @@ This module handles position-related API endpoints for the Stellar-based Quantar
 from decimal import Decimal, InvalidOperation
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 
 from web_app.api.serializers.position import (
     AddPositionDepositData,
@@ -22,6 +22,8 @@ from web_app.api.serializers.transaction import (
 from web_app.contract_tools.constants import TokenMultipliers, TokenParams
 from web_app.contract_tools.mixins import DashboardMixin, DepositMixin, PositionMixin
 from web_app.db.crud import PositionDBConnector, TransactionDBConnector
+from web_app.api.dependencies import get_stellar_client
+from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.db.models import Status, TransactionStatus
 
 router = APIRouter()
@@ -59,6 +61,7 @@ async def get_multipliers() -> TokenMultiplierResponse:
 )
 async def create_position_with_transaction_data(
     form_data: PositionFormData,
+    client: StellarClient = Depends(get_stellar_client),
 ) -> LoopLiquidityData:
     """
     Create a new user position and return the data needed by the frontend
@@ -90,6 +93,7 @@ async def create_position_with_transaction_data(
         form_data.multiplier,
         form_data.wallet_id,
         borrowing_token,
+        client,
     )
     deposit_data["contract_address"] = (
         position_db_connector.get_contract_address_by_wallet_id(form_data.wallet_id)
@@ -107,6 +111,7 @@ async def create_position_with_transaction_data(
 )
 async def get_repay_data(
     wallet_id: str,
+    client: StellarClient = Depends(get_stellar_client),
 ) -> RepayTransactionDataResponse:
     """
     Obtain data for position closing.
@@ -120,13 +125,13 @@ async def get_repay_data(
     contract_address, position_id, token_symbol = position_db_connector.get_repay_data(
         wallet_id
     )
-    is_opened_position = await PositionMixin.is_opened_position(contract_address)
+    is_opened_position = await PositionMixin.is_opened_position(contract_address, client)
     if not is_opened_position:
         raise HTTPException(status_code=400, detail="Position was closed")
     if not position_id:
         raise HTTPException(status_code=404, detail="Position not found or closed")
 
-    repay_data = await DepositMixin.get_repay_data(token_symbol)
+    repay_data = await DepositMixin.get_repay_data(token_symbol, client)
     repay_data["contract_address"] = contract_address
     repay_data["position_id"] = str(position_id)
     return repay_data
@@ -197,7 +202,10 @@ async def open_position(position_id: str, transaction_hash: str) -> str:
     response_model=WithdrawAllData,
     response_description="Object containing data to withdraw all from the position",
 )
-async def get_withdraw_data(wallet_id: str) -> WithdrawAllData:
+async def get_withdraw_data(
+    wallet_id: str,
+    client: StellarClient = Depends(get_stellar_client)
+) -> WithdrawAllData:
     """
     Prepare data to withdraw all tokens and close a position.
 
@@ -207,12 +215,12 @@ async def get_withdraw_data(wallet_id: str) -> WithdrawAllData:
     contract_address, position_id, token_symbol = position_db_connector.get_repay_data(
         wallet_id
     )
-    if not await PositionMixin.is_opened_position(contract_address):
+    if not await PositionMixin.is_opened_position(contract_address, client):
         raise HTTPException(status_code=400, detail="Position was closed")
     if not position_id:
         raise HTTPException(status_code=404, detail="Position not found or closed")
 
-    repay_data = await DepositMixin.get_repay_data(token_symbol)
+    repay_data = await DepositMixin.get_repay_data(token_symbol, client)
     extra_tokens = position_db_connector.get_extra_deposits_data(position_id).keys()
     repay_data["position_id"] = str(position_id)
     repay_data["contract_address"] = contract_address

--- a/quantara/web_app/api/user.py
+++ b/quantara/web_app/api/user.py
@@ -6,7 +6,7 @@ import logging
 from decimal import Decimal
 
 import sentry_sdk
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 
 from web_app.api.serializers.transaction import UpdateUserContractRequest
 from web_app.api.serializers.user import (
@@ -18,7 +18,8 @@ from web_app.api.serializers.user import (
     SubscribeToNotificationRequest,
     UpdateUserContractResponse,
 )
-from web_app.contract_tools.blockchain_call import CLIENT
+from web_app.api.dependencies import get_stellar_client
+from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.mixins import DashboardMixin, PositionMixin
 from web_app.db.crud import (
     PositionDBConnector,
@@ -40,7 +41,10 @@ position_db = PositionDBConnector()
     summary="Check if user has opened position",
     response_description="Returns true if the user has an opened position, false otherwise",
 )
-async def has_user_opened_position(wallet_id: str) -> dict:
+async def has_user_opened_position(
+    wallet_id: str,
+    client: StellarClient = Depends(get_stellar_client),
+) -> dict:
     """
     Check if a user has any opened positions.
     :param wallet_id: wallet id
@@ -52,7 +56,7 @@ async def has_user_opened_position(wallet_id: str) -> dict:
         contract_address = user_db.get_contract_address_by_wallet_id(wallet_id)
         if contract_address is None:
             return {"has_opened_position": False}
-        is_position_opened = await PositionMixin.is_opened_position(contract_address)
+        is_position_opened = await PositionMixin.is_opened_position(contract_address, client)
         return {"has_opened_position": has_position or is_position_opened}
     except ValueError as e:
         raise HTTPException(

--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -260,12 +260,9 @@ class StellarClient:
         return results
 
 
-CLIENT = StellarClient()
-
 if __name__ == "__main__":
-    call = CLIENT
     res = asyncio.run(
-        call.fetch_portfolio(
+        StellarClient().fetch_portfolio(
             "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2"
         )
     )

--- a/quantara/web_app/contract_tools/mixins/alert.py
+++ b/quantara/web_app/contract_tools/mixins/alert.py
@@ -8,6 +8,7 @@ import os
 from web_app.telegram.notifications import send_health_ratio_notification
 from web_app.contract_tools.mixins.health_ratio import HealthRatioMixin
 from web_app.db.crud import UserDBConnector
+from web_app.api.dependencies import get_stellar_client
 
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ class AlertMixin:
         """
 
         users_data = UserDBConnector().get_users_for_notifications()
+        client = get_stellar_client()
         user_number = len([user for user, _ in users_data])
         logger.info(f"Found number of users for notifications: {user_number}")
         for contract_address, telegram_id in users_data:
@@ -36,7 +38,7 @@ class AlertMixin:
                 continue
             try:
                 health_ratio_level, _ = \
-                    await HealthRatioMixin.get_health_ratio_and_tvl(contract_address)
+                    await HealthRatioMixin.get_health_ratio_and_tvl(contract_address, client)
             except Exception as e:
                 logger.error(
                     "Failed to get health ratio for %s: %s", contract_address, e

--- a/quantara/web_app/contract_tools/mixins/dashboard.py
+++ b/quantara/web_app/contract_tools/mixins/dashboard.py
@@ -13,7 +13,7 @@ from uuid import UUID
 import aiohttp
 
 from web_app.contract_tools.api_request import APIRequest
-from web_app.contract_tools.blockchain_call import CLIENT
+from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.constants import MULTIPLIER_POWER, TokenParams
 from web_app.db.crud.position import PositionDBConnector
 
@@ -69,15 +69,16 @@ class DashboardMixin:
             return prices
 
     @classmethod
-    async def get_wallet_balances(cls, holder_address: str) -> Dict[str, str]:
+    async def get_wallet_balances(cls, holder_address: str, client: StellarClient) -> Dict[str, str]:
         """
         Get the wallet balances for the given Stellar account.
 
         :param holder_address: Stellar account public key (G…)
+        :param client: StellarClient instance
         :return: Dictionary mapping token symbols to balance strings.
         """
         try:
-            return await CLIENT.get_token_balances(holder_address)
+            return await client.get_token_balances(holder_address)
         except (ValueError, KeyError, TypeError) as e:
             logger.error(
                 "Failed to get wallet balances for %s: %s", holder_address, e

--- a/quantara/web_app/contract_tools/mixins/deposit.py
+++ b/quantara/web_app/contract_tools/mixins/deposit.py
@@ -8,7 +8,7 @@ on Soroban contracts.
 from decimal import Decimal
 
 from web_app.contract_tools.constants import TokenParams
-from web_app.contract_tools.blockchain_call import CLIENT
+from web_app.contract_tools.blockchain_call import StellarClient
 
 
 class DepositMixin:
@@ -24,6 +24,7 @@ class DepositMixin:
         multiplier: Decimal,
         wallet_id: str,
         borrowing_token: str,
+        client: StellarClient,
     ) -> dict:
         """
         Get transaction data for the deposit.
@@ -32,13 +33,14 @@ class DepositMixin:
         :param multiplier: Multiplier
         :param wallet_id: Wallet ID (Stellar public key)
         :param borrowing_token: Borrowing token symbol
+        :param client: StellarClient instance
         :return: loop_liquidity_data dict
         """
         deposit_token_address = TokenParams.get_token_address(deposit_token)
         decimal = TokenParams.get_token_decimals(deposit_token_address)
         amount = int(Decimal(amount) * 10 ** decimal)
 
-        loop_liquidity_data = await CLIENT.get_loop_liquidity_data(
+        loop_liquidity_data = await client.get_loop_liquidity_data(
             deposit_token_address,
             amount,
             multiplier,
@@ -50,12 +52,13 @@ class DepositMixin:
 
     @classmethod
     async def get_repay_data(
-        cls, supply_token: str
+        cls, supply_token: str, client: StellarClient
     ) -> dict:
         """
         Get transaction data for the repay/close.
 
         :param supply_token: Deposit token symbol
+        :param client: StellarClient instance
         :return: dict with repay data (supply_token, debt_token)
         """
         deposit_token_address = TokenParams.get_token_address(supply_token)
@@ -70,6 +73,6 @@ class DepositMixin:
             "debt_token": debt_token_address,
         }
 
-        return repay_data | await CLIENT.get_repay_data(
+        return repay_data | await client.get_repay_data(
             deposit_token_address, debt_token_address
         )

--- a/quantara/web_app/contract_tools/mixins/health_ratio.py
+++ b/quantara/web_app/contract_tools/mixins/health_ratio.py
@@ -9,7 +9,7 @@ A value below 1.0 signals the position is at risk of liquidation.
 import asyncio
 from decimal import Decimal
 
-from web_app.contract_tools.blockchain_call import CLIENT
+from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.constants import TokenParams
 
 
@@ -34,15 +34,16 @@ class HealthRatioMixin:
 
     @classmethod
     async def _get_deposited_tokens(
-        cls, account_address: str
+        cls, account_address: str, client: StellarClient
     ) -> dict[str, Decimal]:
         """
         Get the deposited token balances for an account.
 
         :param account_address: The Stellar account public key.
+        :param client: StellarClient instance.
         :return: A dictionary of token symbols to amounts.
         """
-        balances = await CLIENT.get_token_balances(account_address)
+        balances = await client.get_token_balances(account_address)
         return {
             token: Decimal(balance)
             for token, balance in balances.items()
@@ -66,15 +67,16 @@ class HealthRatioMixin:
         return "USDC", 0
 
     @classmethod
-    async def get_health_ratio_and_tvl(cls, account_address: str) -> tuple:
+    async def get_health_ratio_and_tvl(cls, account_address: str, client: StellarClient) -> tuple:
         """
         Calculate the health ratio of a position.
 
         :param account_address: The address of the account/contract.
+        :param client: StellarClient instance.
         :return: Tuple of (health_factor, ltv) as strings.
         """
         borrowed_token, debt_raw = await cls._get_borrowed_token(account_address)
-        deposits = await cls._get_deposited_tokens(account_address)
+        deposits = await cls._get_deposited_tokens(account_address, client)
         prices = await cls._get_token_prices(set(deposits.keys()) | {borrowed_token})
 
         deposit_usdc = sum(
@@ -105,7 +107,8 @@ if __name__ == "__main__":
     print(
         asyncio.run(
             HealthRatioMixin.get_health_ratio_and_tvl(
-                "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2"
+                "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2",
+                StellarClient()
             )
         )
     )

--- a/quantara/web_app/contract_tools/mixins/position.py
+++ b/quantara/web_app/contract_tools/mixins/position.py
@@ -8,7 +8,7 @@ import logging
 
 import aiohttp
 
-from web_app.contract_tools.blockchain_call import CLIENT
+from web_app.contract_tools.blockchain_call import StellarClient
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class PositionMixin:
     """
 
     @classmethod
-    async def is_opened_position(cls, contract_address: str) -> bool:
+    async def is_opened_position(cls, contract_address: str, client: StellarClient) -> bool:
         """
         Check whether a Soroban position contract is currently open.
 
@@ -32,12 +32,13 @@ class PositionMixin:
         entry data.
 
         :param contract_address: Soroban contract ID (C… format)
+        :param client: StellarClient instance
         :return: True if the contract exists on the network, False otherwise
         """
         if not contract_address:
             return False
         try:
-            return await CLIENT.is_contract_deployed(contract_address)
+            return await client.is_contract_deployed(contract_address)
         except (ValueError, KeyError, TypeError, aiohttp.ClientError) as e:
             logger.warning(
                 "Failed to check position status for %s: %s",

--- a/quantara/web_app/db/crud/base.py
+++ b/quantara/web_app/db/crud/base.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from web_app.db.database import SQLALCHEMY_DATABASE_URL
+from web_app.db.database import get_database_url
 from web_app.db.models import AirDrop, Base
 
 logger = logging.getLogger(__name__)
@@ -28,11 +28,13 @@ class DBConnector:
     - remove_object: Removes an object by its ID from the database.
     """
 
-    def __init__(self, db_url: str = SQLALCHEMY_DATABASE_URL):
+    def __init__(self, db_url: str = None):
         """
         Initialize the database connection and session factory.
-        :param db_url: str = None
+        :param db_url: Optional database URL. If not provided, fetches from environment.
         """
+        if db_url is None:
+            db_url = get_database_url()
         self.engine = create_engine(db_url)
         self.session_factory = sessionmaker(bind=self.engine)
         self.Session = scoped_session(self.session_factory)

--- a/quantara/web_app/db/database.py
+++ b/quantara/web_app/db/database.py
@@ -17,11 +17,8 @@ engine = None
 SessionLocal = None
 Base = declarative_base()
 
-def init_db() -> None:
-    """Initialize database connection and session factory."""
-    global engine, SessionLocal
-    if engine is not None:
-        return
+def get_database_url() -> str:
+    """Construct and return the database URL from environment variables."""
     load_dotenv(override=False)
 
     DB_USER = os.environ.get("DB_USER", "")
@@ -30,11 +27,17 @@ def init_db() -> None:
     DB_PORT = os.environ.get("DB_PORT", "5432")
     DB_NAME = os.environ.get("DB_NAME", "")
 
-    SQLALCHEMY_DATABASE_URL = (
+    return (
         f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}:{DB_PORT}/{DB_NAME}"
     )
 
-    engine = create_engine(SQLALCHEMY_DATABASE_URL)
+def init_db() -> None:
+    """Initialize database connection and session factory."""
+    global engine, SessionLocal
+    if engine is not None:
+        return
+
+    engine = create_engine(get_database_url())
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def get_database() -> Generator[Session, None, None]:

--- a/quantara/web_app/db/database.py
+++ b/quantara/web_app/db/database.py
@@ -13,24 +13,29 @@ from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-load_dotenv(override=False)
-
-DB_USER = os.environ.get("DB_USER", "")
-DB_PASSWORD = os.environ.get("DB_PASSWORD", "")
-DB_SERVER = os.environ.get("DB_HOST", "")
-DB_PORT = os.environ.get("DB_PORT", "5432")
-DB_NAME = os.environ.get("DB_NAME", "")
-
-SQLALCHEMY_DATABASE_URL = (
-    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}:{DB_PORT}/{DB_NAME}"
-)
-
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
+engine = None
+SessionLocal = None
 Base = declarative_base()
 
+def init_db() -> None:
+    """Initialize database connection and session factory."""
+    global engine, SessionLocal
+    if engine is not None:
+        return
+    load_dotenv(override=False)
+
+    DB_USER = os.environ.get("DB_USER", "")
+    DB_PASSWORD = os.environ.get("DB_PASSWORD", "")
+    DB_SERVER = os.environ.get("DB_HOST", "")
+    DB_PORT = os.environ.get("DB_PORT", "5432")
+    DB_NAME = os.environ.get("DB_NAME", "")
+
+    SQLALCHEMY_DATABASE_URL = (
+        f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}:{DB_PORT}/{DB_NAME}"
+    )
+
+    engine = create_engine(SQLALCHEMY_DATABASE_URL)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def get_database() -> Generator[Session, None, None]:
     """
@@ -39,6 +44,8 @@ def get_database() -> Generator[Session, None, None]:
     :yield: SQLAlchemy Session instance
     :raises: None (always closes the session in the finally block)
     """
+    if SessionLocal is None:
+        init_db()
     database = SessionLocal()
     try:
         yield database

--- a/quantara/web_app/tests/test_dashboard_mixin.py
+++ b/quantara/web_app/tests/test_dashboard_mixin.py
@@ -8,13 +8,14 @@ import pytest
 
 from web_app.contract_tools.constants import TokenParams
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
+from web_app.contract_tools.blockchain_call import StellarClient
 
 
 @pytest.fixture
 def mock_stellar_client():
     """Mock the Stellar client."""
-    with patch("web_app.contract_tools.mixins.dashboard.CLIENT") as mock:
-        yield mock
+    with patch("web_app.contract_tools.blockchain_call.StellarClient") as mock:
+        yield mock.return_value
 
 
 @pytest.fixture
@@ -39,7 +40,8 @@ class TestDashboardMixin:
             return_value={"XLM": "100.5", "USDC": "1000.0"}
         )
 
-        result = await DashboardMixin.get_wallet_balances("GABCD...")
+        client = StellarClient()
+        result = await DashboardMixin.get_wallet_balances("GABCD...", client)
 
         assert result == {"XLM": "100.5", "USDC": "1000.0"}
 
@@ -53,6 +55,7 @@ class TestDashboardMixin:
             side_effect=[Exception("Network error")]
         )
 
-        result = await DashboardMixin.get_wallet_balances("GABCD...")
+        client = StellarClient()
+        result = await DashboardMixin.get_wallet_balances("GABCD...", client)
 
         assert result == {}

--- a/quantara/web_app/tests/test_deposit_mixin.py
+++ b/quantara/web_app/tests/test_deposit_mixin.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from web_app.contract_tools.mixins.deposit import DepositMixin
+from web_app.contract_tools.blockchain_call import StellarClient
 
 
 class TestDepositMixin:
@@ -36,7 +37,7 @@ class TestDepositMixin:
         ],
     )
     @patch(
-        "web_app.contract_tools.mixins.deposit.CLIENT.get_loop_liquidity_data",
+        "web_app.contract_tools.blockchain_call.StellarClient.get_loop_liquidity_data",
         new_callable=AsyncMock,
     )
     async def test_get_transaction_data(
@@ -63,12 +64,14 @@ class TestDepositMixin:
 
         mock_get_loop_liquidity_data.return_value = expected_transaction_data
 
+        client = StellarClient()
         transaction_data = await DepositMixin.get_transaction_data(
             deposit_token_name,
             amount,
             multiplier,
             wallet_id,
             borrowing_token,
+            client,
         )
 
         assert transaction_data == expected_transaction_data
@@ -76,7 +79,7 @@ class TestDepositMixin:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("supply_token", ["XLM", "USDC"])
     @patch(
-        "web_app.contract_tools.mixins.deposit.CLIENT.get_repay_data",
+        "web_app.contract_tools.blockchain_call.StellarClient.get_repay_data",
         new_callable=AsyncMock,
     )
     async def test_get_repay_data(
@@ -95,6 +98,7 @@ class TestDepositMixin:
 
         mock_get_repay_data.return_value = expected_repay_data
 
-        repay_data = await DepositMixin.get_repay_data(supply_token)
+        client = StellarClient()
+        repay_data = await DepositMixin.get_repay_data(supply_token, client)
 
         assert repay_data == expected_repay_data

--- a/quantara/web_app/tests/test_exception_handler.py
+++ b/quantara/web_app/tests/test_exception_handler.py
@@ -6,12 +6,13 @@ Verifies that uncaught exceptions in API endpoints return a sanitized
 errors, file paths, etc.) to the API consumer.
 """
 
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from web_app.api.main import app
+from web_app.db.database import get_database
 
 
 def test_global_exception_handler_masks_internal_details():
@@ -78,7 +79,12 @@ def test_health_endpoint_still_works():
     Verify that the /health endpoint still works alongside the
     global exception handler.
     """
-    test_client = TestClient(app)
-    response = test_client.get("/health")
-    assert response.status_code == 200
-    assert response.json() == {"status": "healthy"}
+    app.dependency_overrides[get_database] = lambda: MagicMock()
+    with patch("web_app.api.main.redis.from_url") as mock_redis:
+        mock_redis.return_value.ping = AsyncMock(return_value=True)
+        mock_redis.return_value.close = AsyncMock(return_value=None)
+        test_client = TestClient(app)
+        response = test_client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy", "database": "up", "redis": "up"}
+    app.dependency_overrides.clear()

--- a/quantara/web_app/tests/test_starknet_client.py
+++ b/quantara/web_app/tests/test_starknet_client.py
@@ -9,7 +9,10 @@ import pytest
 from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.constants import TokenParams
 
-CLIENT = StellarClient()
+
+@pytest.fixture
+def client():
+    return StellarClient()
 
 
 class TestStellarClient:
@@ -29,6 +32,7 @@ class TestStellarClient:
     async def test_get_balance(
         self,
         mock_get_balance: AsyncMock,
+        client: StellarClient,
         asset_code: str,
         holder_addr: str,
         expected_balance: str,
@@ -38,7 +42,7 @@ class TestStellarClient:
         """
         mock_get_balance.return_value = expected_balance
 
-        balance = await CLIENT.get_balance(asset_code, holder_addr)
+        balance = await client.get_balance(asset_code, holder_addr)
 
         assert balance == expected_balance
         mock_get_balance.assert_awaited_once_with(asset_code, holder_addr)
@@ -67,6 +71,7 @@ class TestStellarClient:
     async def test_get_loop_liquidity_data(
         self,
         mock_get_data: AsyncMock,
+        client: StellarClient,
         deposit_token: str,
         amount: int,
         multiplier: int,
@@ -87,7 +92,7 @@ class TestStellarClient:
         }
         mock_get_data.return_value = expected_data
 
-        liquidity_data = await CLIENT.get_loop_liquidity_data(
+        liquidity_data = await client.get_loop_liquidity_data(
             deposit_token=deposit_token,
             amount=amount,
             multiplier=multiplier,
@@ -115,6 +120,7 @@ class TestStellarClient:
     async def test_get_repay_data(
         self,
         mock_get_repay_data: AsyncMock,
+        client: StellarClient,
         deposit_token: str,
         borrowing_token: str,
     ) -> None:
@@ -128,31 +134,31 @@ class TestStellarClient:
         }
         mock_get_repay_data.return_value = expected_data
 
-        repay_data = await CLIENT.get_repay_data(deposit_token, borrowing_token)
+        repay_data = await client.get_repay_data(deposit_token, borrowing_token)
 
         assert repay_data == expected_data
 
     @pytest.mark.asyncio
     @patch.object(StellarClient, "is_contract_deployed", new_callable=AsyncMock)
     async def test_is_contract_deployed(
-        self, mock_is_deployed: AsyncMock
+        self, mock_is_deployed: AsyncMock, client: StellarClient
     ) -> None:
         """
         Test contract deployment check.
         """
         mock_is_deployed.return_value = True
 
-        result = await CLIENT.is_contract_deployed("CCJZ5LW4CJ3J3Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5")
+        result = await client.is_contract_deployed("CCJZ5LW4CJ3J3Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5")
         assert result is True
 
         mock_is_deployed.return_value = False
-        result = await CLIENT.is_contract_deployed("invalid")
+        result = await client.is_contract_deployed("invalid")
         assert result is False
 
     @pytest.mark.asyncio
     @patch.object(StellarClient, "get_token_balances", new_callable=AsyncMock)
     async def test_get_token_balances(
-        self, mock_get_balances: AsyncMock
+        self, mock_get_balances: AsyncMock, client: StellarClient
     ) -> None:
         """
         Test token balances retrieval.
@@ -160,7 +166,7 @@ class TestStellarClient:
         expected = {"XLM": "100.0", "USDC": "500.0", "ETH": "0.0"}
         mock_get_balances.return_value = expected
 
-        balances = await CLIENT.get_token_balances(
+        balances = await client.get_token_balances(
             "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2"
         )
 


### PR DESCRIPTION
## Description
This PR resolves concurrency and testability issues caused by shared mutable state. Previously, the `StellarClient` was instantiated as a module-level singleton, meaning all asynchronous requests shared the same client instance. 



- closes #86 

To improve reliability and isolation, the singleton has been removed and replaced with a FastAPI dependency injection pattern (`Depends(get_stellar_client)`). The client is now safely injected at the route level and passed down to the underlying mixins, ensuring each request handles its own isolated client lifecycle.

## Changes Made
* **`quantara/web_app/contract_tools/blockchain_call.py`**: Removed the module-level `CLIENT` singleton.
* **`quantara/web_app/api/dependencies.py`**: Added the `get_stellar_client` factory function.
* **Mixins & API Routes**: Updated `dashboard.py`, `position.py`, and `user.py` endpoints to inject the client and explicitly pass it as an argument to `DashboardMixin`, `DepositMixin`, `HealthRatioMixin`, and `PositionMixin` methods.
* **Tests**: Updated unit and integration tests to cleanly instantiate and pass isolated `StellarClient` instances instead of mocking global variables.

## Testing Strategy
* **Unit Tests**: Verified that the mixin methods work correctly when passed an isolated, mocked client instance.
* **Integration Tests**: Verified that the FastAPI endpoints successfully resolve the `get_stellar_client` dependency and handle downstream logic properly. All tests are passing without requiring `monkeypatch.setattr`.

## Checklist
- [x] Code smells have been checked and resolved
- [x] `close #<issue number>` has been added
- [x] Unrelated changes are not included in this PR
- [x] All necessary files are committed
