### PR TITLE
security: add pip-audit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,14 @@ repos:
               - --disable=all
               - --enable=C0114,C0115,C0116,C0301
               - --output-format=colorized
+  -   repo: local
+      hooks:
+        -   id: pip-audit
+            name: pip-audit Python dependencies
+            entry: python scripts/audit_python_dependencies.py
+            language: python
+            additional_dependencies:
+              - pip-audit==2.9.0
+              - poetry==2.1.3
+              - poetry-plugin-export==1.9.0
+            pass_filenames: false

--- a/scripts/audit_python_dependencies.py
+++ b/scripts/audit_python_dependencies.py
@@ -1,0 +1,55 @@
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(command, **kwargs):
+    try:
+        return subprocess.run(command, check=True, text=True, **kwargs)
+    except subprocess.CalledProcessError as error:
+        if error.stdout:
+            print(error.stdout, end="")
+        if error.stderr:
+            print(error.stderr, end="", file=sys.stderr)
+        raise
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    app_dir = repo_root / "quantara"
+
+    export_command = [
+        "poetry",
+        "export",
+        "--format",
+        "requirements.txt",
+        "--without-hashes",
+        "--with",
+        "dev",
+    ]
+    export_result = run(export_command, cwd=app_dir, capture_output=True)
+
+    requirements_path = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as requirements:
+            requirements.write(export_result.stdout)
+            requirements_path = requirements.name
+
+        audit_command = [
+            sys.executable,
+            "-m",
+            "pip_audit",
+            "--requirement",
+            requirements_path,
+            "--progress-spinner=off",
+            "--desc=off",
+        ]
+        run(audit_command)
+    finally:
+        if requirements_path:
+            Path(requirements_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a pre-commit hook that runs pip-audit against the Python dependencies
- export Poetry dependencies inside the hook so the audit checks the project dependency set instead of the hook environment
- keep the change limited to pre-commit security tooling

Closes #84

## Validation
- py -3.11 -m py_compile scripts\audit_python_dependencies.py
- py -3.11 scripts\audit_python_dependencies.py
- pre-commit run pip-audit --all-files
- git diff --check