### PR TITLE
ci: add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Stale Issues and Pull Requests
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: security,bug,pinned
+          exempt-pr-labels: security,bug,pinned
+          stale-issue-message: >
+            This issue has been inactive for 60 days and has been marked stale.
+            Comment or remove the stale label if it is still relevant. It will
+            be closed in 14 days if there is no further activity.
+          close-issue-message: >
+            This issue was closed because it remained inactive after being
+            marked stale. Reopen it if the work is still needed.
+          stale-pr-message: >
+            This pull request has been inactive for 30 days and has been marked
+            stale. Please comment or push an update if it is still active.
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- add a scheduled stale workflow using actions/stale
- mark issues stale after 60 days and close them after 14 more days
- mark PRs stale after 30 days without auto-closing them
- exempt security, bug, and pinned items from stale handling

Closes #87

## Validation
- checked workflow content for the requested stale/close thresholds and exempt labels
- git diff --check