### PR TITLE
ci: run database migrations during deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,8 @@ jobs:
             git pull origin main
             echo "Rebuilding and restarting containers..."
             docker compose -f devops/docker-compose.quantara.yaml up -d --build --remove-orphans
+            echo "Applying database migrations..."
+            docker compose -f devops/docker-compose.quantara.yaml exec -T backend alembic -c web_app/alembic.ini upgrade head
             echo "Waiting for services to be healthy..."
             for i in $(seq 1 30); do
               if curl -sf http://localhost:8000/health > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- run Alembic migrations inside the backend container during CD
- apply migrations after containers are rebuilt and before health checks run
- rely on the existing deploy script `set -e` and failure notification step to fail the deployment when migration fails

Closes #85

## Validation
- checked CD command order: deploy, migrate, then health check
- git diff --check