### PR TITLE
fix: restrict CORS allow_origins to configured domains

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -18,12 +18,13 @@ will fail to start in production if any required variable is missing.
 
 ## Optional
 
-| Variable                 | Purpose                                  |
-|--------------------------|------------------------------------------|
-| `DB_PORT`                | PostgreSQL port (default `5432`)         |
-| `ENV_VERSION`            | `PROD` enables production-only behaviour |
-| `STELLAR_HORIZON_URL`    | Stellar Horizon endpoint                 |
-| `STELLAR_SOROBAN_RPC_URL`| Soroban RPC endpoint                     |
+| Variable                  | Purpose                                                     |
+|---------------------------|-------------------------------------------------------------|
+| `CORS_ORIGINS`            | Comma-separated allowed frontend origins                    |
+| `DB_PORT`                 | PostgreSQL port (default `5432`)                            |
+| `ENV_VERSION`             | `PROD` enables production-only behaviour                    |
+| `STELLAR_HORIZON_URL`     | Stellar Horizon endpoint                                    |
+| `STELLAR_SOROBAN_RPC_URL` | Soroban RPC endpoint                                        |
 
 ## Generating a session secret
 
@@ -36,3 +37,11 @@ python -c "import os; print(os.urandom(32).hex())"
 In development (`ENV_VERSION != "PROD"`) the application does not
 require any of the variables above. Missing optional variables
 (e.g. `SENTRY_DSN`) only produce a warning in the logs.
+
+If `CORS_ORIGINS` is unset, the API allows requests from
+`http://localhost:3000` for local development. Set it explicitly in
+production, for example:
+
+```sh
+CORS_ORIGINS="https://quantara.xyz,https://app.quantara.xyz"
+```

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -30,6 +30,24 @@ from web_app.config_validator import assert_valid_config
 from web_app.db.database import init_db, get_database
 
 logger = logging.getLogger(__name__)
+DEFAULT_CORS_ORIGINS = ["http://localhost:3000"]
+CORS_ALLOW_METHODS = ["GET", "POST"]
+CORS_ALLOW_HEADERS = ["Content-Type", "Authorization"]
+
+
+def get_cors_origins() -> list[str]:
+    """
+    Return the allowed CORS origins from the environment.
+
+    A comma-separated CORS_ORIGINS value is supported for production. When the
+    variable is unset or blank, development keeps working against localhost.
+    """
+    raw_origins = os.getenv("CORS_ORIGINS")
+    if not raw_origins:
+        return DEFAULT_CORS_ORIGINS
+
+    origins = [origin.strip() for origin in raw_origins.split(",")]
+    return [origin for origin in origins if origin] or DEFAULT_CORS_ORIGINS
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -104,7 +122,10 @@ _session_secret = os.getenv("SESSION_SECRET_KEY", os.urandom(32).hex())
 app.add_middleware(SessionMiddleware, secret_key=_session_secret)
 # CORS middleware for React frontend
 app.add_middleware(
-    CORSMiddleware, allow_origins=["*"], allow_headers=["*"], allow_methods=["*"]
+    CORSMiddleware,
+    allow_origins=get_cors_origins(),
+    allow_headers=CORS_ALLOW_HEADERS,
+    allow_methods=CORS_ALLOW_METHODS,
 )
 
 

--- a/quantara/web_app/tests/test_cors_config.py
+++ b/quantara/web_app/tests/test_cors_config.py
@@ -1,0 +1,50 @@
+"""
+Tests for the FastAPI CORS configuration.
+"""
+
+from starlette.middleware.cors import CORSMiddleware
+
+from web_app.api.main import (
+    CORS_ALLOW_HEADERS,
+    CORS_ALLOW_METHODS,
+    DEFAULT_CORS_ORIGINS,
+    app,
+    get_cors_origins,
+)
+
+
+def test_cors_origins_default_to_localhost_when_unset(monkeypatch):
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+
+    assert get_cors_origins() == DEFAULT_CORS_ORIGINS
+
+
+def test_cors_origins_are_trimmed_and_split(monkeypatch):
+    monkeypatch.setenv(
+        "CORS_ORIGINS",
+        " https://quantara.xyz , http://localhost:3000 , https://app.quantara.xyz ",
+    )
+
+    assert get_cors_origins() == [
+        "https://quantara.xyz",
+        "http://localhost:3000",
+        "https://app.quantara.xyz",
+    ]
+
+
+def test_blank_cors_origins_fall_back_to_localhost(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", " , ")
+
+    assert get_cors_origins() == DEFAULT_CORS_ORIGINS
+
+
+def test_app_registers_restricted_cors_policy():
+    cors_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls is CORSMiddleware
+    )
+
+    assert cors_middleware.kwargs["allow_origins"] == DEFAULT_CORS_ORIGINS
+    assert cors_middleware.kwargs["allow_methods"] == CORS_ALLOW_METHODS
+    assert cors_middleware.kwargs["allow_headers"] == CORS_ALLOW_HEADERS


### PR DESCRIPTION
## Summary
- Replace wildcard CORS origins with env-driven allowlists.
- Restrict allowed methods to GET/POST and allowed headers to Content-Type/Authorization.
- Document the new `CORS_ORIGINS` variable and local-development fallback.

## Validation
- `python -m py_compile web_app/api/main.py web_app/tests/test_cors_config.py web_app/tests/test_exception_handler.py`
- `poetry run pytest web_app/tests/test_cors_config.py web_app/tests/test_exception_handler.py`
- `poetry run pytest web_app/tests` was run, but the repository currently has unrelated pre-existing failures in user/vault/airdrop coverage.

Closes #40