### PR TITLE
fix: migrate price oracle to CoinGecko

### DIFF
--- a/quantara/web_app/contract_tools/mixins/dashboard.py
+++ b/quantara/web_app/contract_tools/mixins/dashboard.py
@@ -20,8 +20,13 @@ from web_app.db.crud.position import PositionDBConnector
 logger = logging.getLogger(__name__)
 position_db_connector = PositionDBConnector()
 
-# AVNU price endpoint (Stellar-compatible market data API)
-AVNU_PRICE_URL = "https://starknet.impulse.avnu.fi/v1/tokens/short"
+# CoinGecko price endpoint for Stellar-compatible market data.
+COINGECKO_PRICE_URL = "https://api.coingecko.com/api/v3/simple/price"
+TOKEN_PRICE_IDS = {
+    "XLM": "stellar",
+    "USDC": "usd-coin",
+    "ETH": "ethereum",
+}
 
 
 class DashboardMixin:
@@ -32,36 +37,36 @@ class DashboardMixin:
     @classmethod
     async def get_current_prices(cls) -> Dict[str, Decimal]:
         """
-        Fetch current token prices from AVNU API.
+        Fetch current token prices from CoinGecko.
 
-        Queries the AVNU token-short endpoint to retrieve latest market
-        prices for all supported tokens. Maps addresses to token symbols
-        for Quantara's internal representation.
+        Queries CoinGecko's simple price endpoint for the supported
+        Stellar-compatible tokens and maps the response back to the
+        internal token symbols used throughout Quantara.
 
         :return: Dictionary mapping token symbols to their current prices as Decimal.
         :raises: None (returns empty dict on any failure)
         """
         prices = {}
         try:
-            response = await APIRequest(base_url=AVNU_PRICE_URL).fetch("")
-            if not response:
+            response = await APIRequest(base_url=COINGECKO_PRICE_URL).fetch(
+                "",
+                params={
+                    "ids": ",".join(TOKEN_PRICE_IDS.values()),
+                    "vs_currencies": "usd",
+                },
+            )
+            if not isinstance(response, dict):
                 return prices
 
-            for token_data in response:
-                address = token_data.get("address")
-                current_price = token_data.get("currentPrice")
-                try:
-                    if address and current_price is not None:
-                        # Map token addresses to symbols
-                        symbol = token_data.get("symbol", "")
-                        if symbol.upper() in ("ETH", "USDC", "XLM", "STRK"):
-                            prices[symbol.upper()] = Decimal(str(current_price))
-                        elif "eth" in symbol.lower():
-                            prices["ETH"] = Decimal(str(current_price))
-                        elif "usdc" in symbol.lower():
-                            prices["USDC"] = Decimal(str(current_price))
-                except (AttributeError, TypeError, ValueError) as e:
-                    logger.debug(f"Error parsing price for {address}: {str(e)}")
+            for symbol, token_id in TOKEN_PRICE_IDS.items():
+                token_data = response.get(token_id)
+                current_price = (
+                    token_data.get("usd")
+                    if isinstance(token_data, dict)
+                    else None
+                )
+                if current_price is not None:
+                    prices[symbol] = Decimal(str(current_price))
 
             return prices
         except (aiohttp.ClientError, ValueError, KeyError, TypeError) as e:
@@ -131,15 +136,15 @@ class DashboardMixin:
         )
 
         for extra_deposit in extra_deposits:
-            if extra_deposit.token_symbol in current_prices:
+            extra_price = current_prices.get(extra_deposit.token_symbol)
+            if extra_price is not None:
                 deposit_amount = Decimal(extra_deposit.amount)
-                if extra_deposit.token_symbol != main_position.token_symbol:
-                    deposit_amount *= Decimal(
-                        current_prices[extra_deposit.token_symbol]
-                    )
-                    deposit_amount /= Decimal(
-                        current_prices[main_position.token_symbol]
-                    )
+                if (
+                    extra_deposit.token_symbol != main_position.token_symbol
+                    and base_price is not None
+                ):
+                    deposit_amount *= Decimal(extra_price)
+                    deposit_amount /= Decimal(base_price)
                 total_sum += deposit_amount
 
         return total_sum

--- a/quantara/web_app/tests/test_dashboard_mixin.py
+++ b/quantara/web_app/tests/test_dashboard_mixin.py
@@ -2,20 +2,14 @@
 Test suite for the DashboardMixin class (Stellar-based).
 """
 
+from decimal import Decimal
 from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
 
 import pytest
 
-from web_app.contract_tools.constants import TokenParams
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
-from web_app.contract_tools.blockchain_call import StellarClient
-
-
-@pytest.fixture
-def mock_stellar_client():
-    """Mock the Stellar client."""
-    with patch("web_app.contract_tools.blockchain_call.StellarClient") as mock:
-        yield mock.return_value
+from web_app.db.models import ExtraDeposit
 
 
 @pytest.fixture
@@ -30,32 +24,81 @@ class TestDashboardMixin:
     Test cases for the DashboardMixin class.
     """
 
-    @pytest.mark.skip(reason="CLIENT mock needs updating for Stellar client compatibility")
     @pytest.mark.asyncio
-    async def test_get_wallet_balances_success(self, mock_stellar_client):
+    async def test_get_current_prices_returns_coingecko_prices(self, mock_api_request):
         """
-        Test successful retrieval of wallet balances.
+        Test that CoinGecko responses are mapped to Quantara token symbols.
         """
-        mock_stellar_client.get_token_balances = AsyncMock(
-            return_value={"XLM": "100.5", "USDC": "1000.0"}
+        mock_api_request.return_value.fetch = AsyncMock(
+            return_value={
+                "stellar": {"usd": 0.123},
+                "usd-coin": {"usd": 1},
+                "ethereum": {"usd": 2500.45},
+            }
         )
 
-        client = StellarClient()
-        result = await DashboardMixin.get_wallet_balances("GABCD...", client)
+        result = await DashboardMixin.get_current_prices()
 
-        assert result == {"XLM": "100.5", "USDC": "1000.0"}
-
-    @pytest.mark.skip(reason="CLIENT mock needs updating for Stellar client compatibility")
-    @pytest.mark.asyncio
-    async def test_get_wallet_balances_error_handling(self, mock_stellar_client):
-        """
-        Test wallet balances retrieval with error handling.
-        """
-        mock_stellar_client.get_token_balances = AsyncMock(
-            side_effect=[Exception("Network error")]
+        assert result == {
+            "XLM": Decimal("0.123"),
+            "USDC": Decimal("1"),
+            "ETH": Decimal("2500.45"),
+        }
+        mock_api_request.assert_called_once()
+        mock_api_request.return_value.fetch.assert_awaited_once_with(
+            "",
+            params={
+                "ids": "stellar,usd-coin,ethereum",
+                "vs_currencies": "usd",
+            },
         )
 
-        client = StellarClient()
-        result = await DashboardMixin.get_wallet_balances("GABCD...", client)
+    @pytest.mark.asyncio
+    async def test_get_current_prices_returns_empty_dict_for_invalid_payload(
+        self, mock_api_request
+    ):
+        """
+        Test that malformed API responses fail closed.
+        """
+        mock_api_request.return_value.fetch = AsyncMock(return_value=["invalid"])
+
+        result = await DashboardMixin.get_current_prices()
 
         assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_current_position_sum_converts_extra_deposits(
+        self, mock_api_request
+    ):
+        """
+        Test that current position values are derived from the configured prices.
+        """
+        mock_position = SimpleNamespace(
+            token_symbol="XLM",
+            amount="1",
+            multiplier="1",
+        )
+        mock_prices = {
+            "XLM": Decimal("99"),
+            "ETH": Decimal("198"),
+            "USDC": Decimal("1"),
+        }
+        with (
+            patch(
+                "web_app.contract_tools.mixins.dashboard.position_db_connector.get_position_by_id",
+                return_value=mock_position,
+            ),
+            patch(
+                "web_app.contract_tools.mixins.dashboard.position_db_connector.get_extra_deposits_by_position_id",
+                return_value=[ExtraDeposit(token_symbol="ETH", amount="1")],
+            ),
+            patch.object(
+                DashboardMixin,
+                "get_current_prices",
+                new_callable=AsyncMock,
+                return_value=mock_prices,
+            ),
+        ):
+            result = await DashboardMixin.get_current_position_sum({"id": "pos-1"})
+
+        assert result == Decimal("102")


### PR DESCRIPTION
## Summary
- Replace the Starknet AVNU price feed with CoinGecko's simple price endpoint.
- Map CoinGecko prices back to the Quantara token symbols XLM, USDC, and ETH.
- Add direct coverage for the new price parsing and position-value conversion path.

## Validation
- `python -m py_compile web_app/contract_tools/mixins/dashboard.py web_app/tests/test_dashboard_mixin.py`
- `poetry run pytest web_app/tests/test_dashboard_mixin.py web_app/tests/test_dashboard.py`
- `poetry run pytest web_app/tests` still has pre-existing backend failures unrelated to this change (database setup, user, vault, and airdrop tests).
- `npm run build` in `quantara/frontend` could not be completed because frontend dependencies are not installed in this workspace (`vite` is missing and `node_modules` is absent).

Closes #55