### PR TITLE
fix(security): replace hardcoded DB_PASSWORD with env var in dev docker-compose configs (#43)

### DIFF
--- a/devops/docker-compose.quantara.back.yaml
+++ b/devops/docker-compose.quantara.back.yaml
@@ -29,7 +29,7 @@ services:
       - DB_PORT=5432
       - DB_NAME=quantara
       - DB_USER=postgres
-      - DB_PASSWORD=password
+      - DB_PASSWORD=${DB_PASSWORD:-password}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 15s
@@ -44,7 +44,7 @@ services:
     environment:
       POSTGRES_DB: quantara
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
       - ../quantara/init-db:/docker-entrypoint-initdb.d

--- a/devops/docker-compose.quantara.dev-windows.yaml
+++ b/devops/docker-compose.quantara.dev-windows.yaml
@@ -27,7 +27,7 @@ services:
       - DB_PORT=5432
       - DB_NAME=quantara
       - DB_USER=postgres
-      - DB_PASSWORD=password
+      - DB_PASSWORD=${DB_PASSWORD:-password}
 
   db:
     image: postgres:16
@@ -35,7 +35,7 @@ services:
     environment:
       POSTGRES_DB: quantara
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
       - ../quantara/init-db:/docker-entrypoint-initdb.d

--- a/devops/docker-compose.quantara.dev.yaml
+++ b/devops/docker-compose.quantara.dev.yaml
@@ -27,7 +27,7 @@ services:
       - DB_PORT=5432
       - DB_NAME=quantara
       - DB_USER=postgres
-      - DB_PASSWORD=password
+      - DB_PASSWORD=${DB_PASSWORD:-password}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 15s
@@ -42,7 +42,7 @@ services:
     environment:
       POSTGRES_DB: quantara
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
       - ../quantara/init-db:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## Summary

Resolves #43 — three docker-compose development files hardcoded `DB_PASSWORD=password` and `POSTGRES_PASSWORD=password` as literal strings. If a developer copied this pattern to production the database would have a known, guessable password. Inconsistency with the production config (which correctly uses `${DB_PASSWORD}`) also creates confusion.

### Changes

Replaced hardcoded `password` with `${DB_PASSWORD:-password}` in:

| File | Before | After |
|------|--------|-------|
| `devops/docker-compose.quantara.dev.yaml` | `DB_PASSWORD=password` | `DB_PASSWORD=${DB_PASSWORD:-password}` |
| `devops/docker-compose.quantara.dev.yaml` | `POSTGRES_PASSWORD: password` | `POSTGRES_PASSWORD: ${DB_PASSWORD:-password}` |
| `devops/docker-compose.quantara.back.yaml` | same | same |
| `devops/docker-compose.quantara.dev-windows.yaml` | same | same |

The `:-password` fallback means:
- **No env var set** → uses `password` as before (zero friction for existing devs)
- **`DB_PASSWORD` set in host environment** → uses that value (enables teams to set stronger passwords)

The `quantara/.env.dev` file already contains `DB_PASSWORD=password` and was not changed.

The CI workflow files (`.github/workflows/ci.yml`, `integration-tests.yml`) were intentionally left unchanged — they already set `DB_PASSWORD: password` explicitly as environment variables for the test runner.

## Test plan
- [x] `docker compose -f devops/docker-compose.quantara.dev.yaml up -d` still works without any extra config (fallback `password` applies)
- [x] Setting `DB_PASSWORD=testpass` in host env before compose-up correctly propagates to the container
- [x] CI passes — compose files are not executed by CI; only pytest and alembic run

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)