### PR TITLE
refactor: Migrate Position, ExtraDeposit, and Vault amount columns to…

### DIFF
--- a/quantara/web_app/alembic/versions/20230620_amount_numeric.py
+++ b/quantara/web_app/alembic/versions/20230620_amount_numeric.py
@@ -1,0 +1,75 @@
+"""migration: convert amount columns to Numeric(38,18)
+
+Revision ID: 20230620_amount_numeric
+Revises: b705d1435b64
+Create Date: 2026-06-20 01:18:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '20230620_amount_numeric'
+down_revision = 'b705d1435b64'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Position.amount
+    op.alter_column(
+        'position',
+        'amount',
+        existing_type=sa.String(),
+        type_=sa.Numeric(38, 18),
+        postgresql_using='amount::numeric',
+        nullable=False,
+    )
+    # ExtraDeposit.amount
+    op.alter_column(
+        'extra_deposits',
+        'amount',
+        existing_type=sa.String(),
+        type_=sa.Numeric(38, 18),
+        postgresql_using='amount::numeric',
+        nullable=False,
+    )
+    # Vault.amount
+    op.alter_column(
+        'vault',
+        'amount',
+        existing_type=sa.String(),
+        type_=sa.Numeric(38, 18),
+        postgresql_using='amount::numeric',
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Position.amount back to String
+    op.alter_column(
+        'position',
+        'amount',
+        existing_type=sa.Numeric(38, 18),
+        type_=sa.String(),
+        postgresql_using='amount::text',
+        nullable=False,
+    )
+    # ExtraDeposit.amount back to String
+    op.alter_column(
+        'extra_deposits',
+        'amount',
+        existing_type=sa.Numeric(38, 18),
+        type_=sa.String(),
+        postgresql_using='amount::text',
+        nullable=False,
+    )
+    # Vault.amount back to String (nullable)
+    op.alter_column(
+        'vault',
+        'amount',
+        existing_type=sa.Numeric(38, 18),
+        type_=sa.String(),
+        postgresql_using='amount::text',
+        nullable=True,
+    )

--- a/quantara/web_app/db/crud/deposit.py
+++ b/quantara/web_app/db/crud/deposit.py
@@ -64,8 +64,8 @@ class DepositDBConnector(DBConnector):
         if not vault:
             raise ValueError("Vault not found")
         with self.Session() as db:
-            new_amount = Decimal(vault.amount) + Decimal(amount)
-            db.query(Vault).filter_by(id=vault.id).update(amount=str(new_amount))
+            new_amount = Decimal(str(vault.amount or 0)) + Decimal(amount)
+            db.query(Vault).filter_by(id=vault.id).update({"amount": new_amount})
             db.commit()
             vault = self.get_vault(wallet_id, symbol)
         return vault
@@ -80,4 +80,5 @@ class DepositDBConnector(DBConnector):
         :returns: str or None
         """
         vault = self.get_vault(wallet_id, symbol)
-        return vault.amount if vault else None
+        return str(vault.amount) if (vault and vault.amount is not None) else None
+

--- a/quantara/web_app/db/crud/position.py
+++ b/quantara/web_app/db/crud/position.py
@@ -39,7 +39,7 @@ class PositionDBConnector(UserDBConnector):
             "id": str(position.id),
             "user_id": str(position.user_id),
             "token_symbol": position.token_symbol,
-            "amount": position.amount,
+            "amount": str(position.amount),
             "multiplier": position.multiplier,
             "created_at": (
                 position.created_at.isoformat() if position.created_at else None
@@ -334,7 +334,7 @@ class PositionDBConnector(UserDBConnector):
                 token_amounts = (
                     db.query(
                         Position.token_symbol,
-                        func.sum(cast(Position.amount, Numeric)).label("total_amount"),
+                        func.sum(Position.amount).label("total_amount"),
                     )
                     .filter(Position.status != Status.PENDING.value)
                     .group_by(Position.token_symbol)
@@ -487,7 +487,7 @@ class PositionDBConnector(UserDBConnector):
                 .on_conflict_do_update(
                     index_elements=["position_id", "token_symbol"],
                     set_={
-                        "amount": cast(ExtraDeposit.amount, Numeric) + cast(amount, Numeric)
+                        "amount": ExtraDeposit.amount + cast(amount, Numeric)
                     },
                 )
             )
@@ -507,7 +507,7 @@ class PositionDBConnector(UserDBConnector):
                 .filter(ExtraDeposit.position_id == position_id)
                 .all()
             )
-            return {deposit.token_symbol: deposit.amount for deposit in deposits}
+            return {deposit.token_symbol: str(deposit.amount) for deposit in deposits}
 
     def get_extra_deposits_by_position_id(self, position_id: UUID) -> list[ExtraDeposit]:
         """

--- a/quantara/web_app/db/models.py
+++ b/quantara/web_app/db/models.py
@@ -83,7 +83,7 @@ class Position(Base):
         UUID(as_uuid=True), ForeignKey("user.id"), index=True, nullable=False
     )
     token_symbol = Column(String, nullable=False)
-    amount = Column(String, nullable=False)
+    amount = Column(NUMERIC(38, 18), nullable=False)
     multiplier = Column(NUMERIC, nullable=False)
 
     created_at = Column(DateTime, nullable=False, default=func.now())
@@ -154,7 +154,7 @@ class Vault(Base):
         UUID(as_uuid=True), ForeignKey("user.id"), index=True, nullable=False
     )
     symbol = Column(String)
-    amount = Column(String)
+    amount = Column(NUMERIC(38, 18))
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(
         DateTime, nullable=False, default=func.now(), onupdate=func.now()
@@ -217,7 +217,7 @@ class ExtraDeposit(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     token_symbol = Column(String, nullable=False)
-    amount = Column(String, nullable=False)
+    amount = Column(NUMERIC(38, 18), nullable=False)
     added_at = Column(DateTime, default=func.now())
     updated_at = Column(
         DateTime, nullable=False, default=func.now(), onupdate=func.now()

--- a/quantara/web_app/tests/db/deposit_db_tests.py
+++ b/quantara/web_app/tests/db/deposit_db_tests.py
@@ -104,9 +104,9 @@ class TestAddVaultBalance:
             amount="50.00",
         )
 
-        updated_amount = Decimal(mock_vault.amount) + Decimal("50.00")
+        updated_amount = Decimal(str(mock_vault.amount)) + Decimal("50.00")
         mock_db_connector.Session().query().filter_by().update.assert_called_once_with(
-            {"amount": str(updated_amount)}
+            {"amount": updated_amount}
         )
 
     def test_add_balance_failure_vault_not_found(


### PR DESCRIPTION
this pr closes #77 The amount column in the Position, ExtraDeposit, and Vault models was previously a String, causing type‑mismatch bugs and requiring runtime casts to NUMERIC for every calculation.

This PR migrates those columns to NUMERIC(38, 18), updates the corresponding CRUD logic to operate on native Decimal values, adds an Alembic migration to perform the schema change safely, and adjusts test expectations.

Changes include:

Model definitions updated (models.py).
Removal of cast(..., Numeric) from query logic (position.py).
Direct Decimal math in vault balance updates (deposit.py).
Alembic migration script (20230620_amount_numeric.py).
Test suite updated (deposit_db_tests.py).
All tests run successfully (pytest), confirming functional correctness.