### PR TITLE
feat: wallet signature verification middleware for API auth (closes #41)

### DIFF
--- a/quantara/frontend/src/services/contract.js
+++ b/quantara/frontend/src/services/contract.js
@@ -21,7 +21,7 @@ import {
 import { getWalletPublicKey, signStellarTransaction, getNetworkPassphrase } from './wallet';
 import { getSorobanServer, pollForTransaction } from './soroban';
 import { SOROBAN_WASM_HASH } from '../utils/constants';
-import { axiosInstance } from '../utils/axios';
+import { axiosInstance, getAuthHeaders } from '../utils/axios';
 import { notify, ToastWithLink } from '../components/layout/notifier/Notifier';
 
 /**
@@ -193,11 +193,12 @@ export async function checkAndDeployContract(walletId) {
 
       console.log('Contract address:', contractAddress);
 
-      // Update the backend with deployment info
+      // Update the backend with deployment info (requires wallet auth headers)
+      const authHeaders = await getAuthHeaders(walletId);
       await axiosInstance.post(`/api/update-user-contract`, {
         wallet_id: walletId,
         contract_address: contractAddress,
-      });
+      }, { headers: authHeaders });
       console.log('Backend updated with deployment information.');
     } else {
       console.log('Contract is already deployed for wallet ID:', walletId);

--- a/quantara/frontend/src/services/transaction.js
+++ b/quantara/frontend/src/services/transaction.js
@@ -9,7 +9,7 @@
 
 import { getWalletPublicKey } from './wallet';
 import { invokeSorobanContract } from './soroban';
-import { axiosInstance } from '../utils/axios';
+import { axiosInstance, getAuthHeaders } from '../utils/axios';
 import { notify, ToastWithLink } from '../components/layout/notifier/Notifier';
 import { STELLAR_NETWORK } from '../utils/constants';
 
@@ -256,8 +256,9 @@ export const handleTransaction = async (connectedWalletId, formData, setTokenAmo
       return;
     }
 
-    // Get position data from backend
-    const response = await axiosInstance.post(`/api/create-position`, formData);
+    // Get position data from backend (requires wallet auth headers)
+    const authHeaders = await getAuthHeaders(connectedWalletId);
+    const response = await axiosInstance.post(`/api/create-position`, formData, { headers: authHeaders });
     const transactionData = response.data;
 
     console.log('Position data received:', transactionData);

--- a/quantara/frontend/src/services/wallet.jsx
+++ b/quantara/frontend/src/services/wallet.jsx
@@ -14,6 +14,7 @@ import {
   isConnected,
   getPublicKey,
   signTransaction,
+  signMessage,
 } from '@stellar/freighter-api';
 import { StrKey } from '@stellar/stellar-sdk';
 
@@ -205,6 +206,26 @@ export const getBalances = async (walletId, setBalances) => {
   } catch (error) {
     console.error('Error fetching user balances:', error);
   }
+};
+
+/**
+ * Sign a nonce string for API authentication using the Freighter wallet.
+ *
+ * Freighter's signMessage returns the Ed25519 signature as a base64-encoded string.
+ * We convert it to hex to match the backend's bytes.fromhex() expectation.
+ *
+ * @param {string} nonce - The nonce string obtained from GET /api/auth/nonce
+ * @param {string} walletId - The Stellar public key of the signer
+ * @returns {Promise<string>} Hex-encoded Ed25519 signature
+ */
+export const signNonce = async (nonce, walletId) => {
+  const result = await signMessage(nonce, { address: walletId });
+  if (result.error) {
+    throw new Error(`Failed to sign nonce: ${result.error}`);
+  }
+  // signedMessage is a base64 string — convert to hex for backend
+  const raw = atob(result.signedMessage);
+  return Array.from(raw, (c) => c.charCodeAt(0).toString(16).padStart(2, '0')).join('');
 };
 
 export const disconnectWallet = async () => {

--- a/quantara/frontend/src/utils/axios.js
+++ b/quantara/frontend/src/utils/axios.js
@@ -25,3 +25,22 @@ axiosInstance.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+/**
+ * Build the three auth headers required by protected API endpoints.
+ *
+ * Flow: GET /api/auth/nonce → sign nonce with Freighter → return headers.
+ *
+ * @param {string} walletId - The Stellar public key (G...)
+ * @returns {Promise<{'x-wallet-id': string, 'x-nonce': string, 'x-signature': string}>}
+ */
+export const getAuthHeaders = async (walletId) => {
+  const { signNonce } = await import('../services/wallet');
+  const { data } = await axiosInstance.get('/api/auth/nonce', { params: { wallet_id: walletId } });
+  const signature = await signNonce(data.nonce, walletId);
+  return {
+    'x-wallet-id': walletId,
+    'x-nonce': data.nonce,
+    'x-signature': signature,
+  };
+};

--- a/quantara/frontend/test/services/contract.test.js
+++ b/quantara/frontend/test/services/contract.test.js
@@ -12,7 +12,13 @@ vi.mock('../../src/services/wallet', () => ({
   getNetworkPassphrase: vi.fn(() => 'Test SDF Network ; September 2015'),
 }));
 
-vi.mock('../../src/utils/axios');
+vi.mock('../../src/utils/axios', () => ({
+  axiosInstance: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  getAuthHeaders: vi.fn().mockResolvedValue({ 'x-wallet-id': 'mock', 'x-nonce': 'mock', 'x-signature': 'mock' }),
+}));
 vi.mock('../../src/utils/constants', () => ({
   SOROBAN_WASM_HASH: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
 }));
@@ -231,7 +237,7 @@ describe('Contract Deployment Tests', () => {
       expect(axiosInstance.post).toHaveBeenCalledWith('/api/update-user-contract', {
         wallet_id: mockWalletId,
         contract_address: mockContractId,
-      });
+      }, { headers: { 'x-wallet-id': 'mock', 'x-nonce': 'mock', 'x-signature': 'mock' } });
     });
 
     it('should skip deployment if contract already exists', async () => {

--- a/quantara/frontend/test/services/transaction.test.js
+++ b/quantara/frontend/test/services/transaction.test.js
@@ -15,7 +15,13 @@ vi.mock('../../src/services/soroban', () => ({
   invokeSorobanContract: vi.fn(),
 }));
 
-vi.mock('../../src/utils/axios');
+vi.mock('../../src/utils/axios', () => ({
+  axiosInstance: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  getAuthHeaders: vi.fn().mockResolvedValue({ 'x-wallet-id': 'mock', 'x-nonce': 'mock', 'x-signature': 'mock' }),
+}));
 vi.mock('../../src/services/contract');
 
 describe('Transaction Functions', () => {
@@ -108,7 +114,7 @@ describe('Transaction Functions', () => {
 
       expect(mockSetLoading).toHaveBeenCalledWith(true);
       expect(getWalletPublicKey).toHaveBeenCalled();
-      expect(axiosInstance.post).toHaveBeenCalledWith('/api/create-position', mockFormData);
+      expect(axiosInstance.post).toHaveBeenCalledWith('/api/create-position', mockFormData, { headers: { 'x-wallet-id': 'mock', 'x-nonce': 'mock', 'x-signature': 'mock' } });
       expect(invokeSorobanContract).toHaveBeenCalled();
       expect(axiosInstance.get).toHaveBeenCalledWith('/api/open-position', {
         params: { position_id: 1, transaction_hash: mockTransactionHash },

--- a/quantara/web_app/api/dependencies.py
+++ b/quantara/web_app/api/dependencies.py
@@ -2,10 +2,15 @@
 API dependencies for the Quantara FastAPI application.
 """
 
+from web_app.api.wallet_auth import verify_wallet_signature
 from web_app.contract_tools.blockchain_call import StellarClient
+
 
 def get_stellar_client() -> StellarClient:
     """
     FastAPI dependency that returns a StellarClient instance.
     """
     return StellarClient()
+
+
+__all__ = ["get_stellar_client", "verify_wallet_signature"]

--- a/quantara/web_app/api/user.py
+++ b/quantara/web_app/api/user.py
@@ -18,7 +18,7 @@ from web_app.api.serializers.user import (
     SubscribeToNotificationRequest,
     UpdateUserContractResponse,
 )
-from web_app.api.dependencies import get_stellar_client
+from web_app.api.dependencies import get_stellar_client, verify_wallet_signature
 from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.mixins import DashboardMixin, PositionMixin
 from web_app.db.crud import (
@@ -135,6 +135,7 @@ async def check_user(request: Request, wallet_id: str) -> CheckUserResponse:
 async def update_user_contract(
     request: Request,
     data: UpdateUserContractRequest,
+    wallet: str = Depends(verify_wallet_signature),
 ) -> UpdateUserContractResponse:
     """
     This endpoint updates the user's contract.
@@ -165,6 +166,7 @@ async def update_user_contract(
 async def subscribe_to_notification(
     request: Request,
     data: SubscribeToNotificationRequest,
+    wallet: str = Depends(verify_wallet_signature),
 ):
     """
     This endpoint subscribes a user to notifications by linking their telegram ID to their wallet.

--- a/quantara/web_app/tests/test_positions.py
+++ b/quantara/web_app/tests/test_positions.py
@@ -20,8 +20,6 @@ from web_app.api.main import app
 from web_app.db.models import TransactionStatus
 from web_app.tests.conftest import dict_to_object
 
-app.dependency_overrides.clear()
-
 
 @pytest.mark.anyio
 async def test_open_position_success(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

Implements Ed25519 Stellar wallet signature verification middleware for all state-changing API endpoints, closing the critical authentication bypass described in issue #41.

## Changes

### Backend
- **`web_app/api/wallet_auth.py`** *(existing)* — nonce generation, Ed25519 verification, `verify_wallet_signature` FastAPI dependency, `GET /api/auth/nonce` endpoint
- **`web_app/api/dependencies.py`** — re-exports `verify_wallet_signature` alongside `get_stellar_client` for clean import paths
- **`web_app/api/user.py`** — added `Depends(verify_wallet_signature)` to `POST /api/update-user-contract` and `POST /api/subscribe-to-notification` (previously unprotected)
- `position.py` and `vault.py` were already protected

### Frontend
- **`services/wallet.jsx`** — adds `signNonce(nonce, walletId)` using Freighter's `signMessage` API; converts base64 → hex to match backend `bytes.fromhex()`
- **`utils/axios.js`** — adds `getAuthHeaders(walletId)`: fetches nonce from `/api/auth/nonce`, signs it, returns `x-wallet-id` / `x-nonce` / `x-signature` headers
- **`services/transaction.js`** — `POST /api/create-position` now includes auth headers
- **`services/contract.js`** — `POST /api/update-user-contract` now includes auth headers

### Tests
- **`tests/test_positions.py`** — removed module-level `app.dependency_overrides.clear()` that was wiping the `bypass_wallet_auth` autouse fixture and causing auth failures on protected endpoints
- **`tests/conftest.py`** *(existing)* — `bypass_wallet_auth` autouse fixture keeps all existing test suites decoupled from real crypto; `test_wallet_auth.py` covers the full auth flow with 23 unit tests

## Test Results

- ✅ 23/23 wallet auth unit tests pass
- ✅ All position/vault endpoint tests pass with the auth bypass fixture
- ✅ 1 pre-existing DB-connection failure in `test_positions.py` (no local Postgres) — unchanged from `main`

## Acceptance Criteria

- [x] POST/PUT/DELETE endpoints require valid Ed25519 signature matching claimed `wallet_id`
- [x] GET endpoints for public data remain unauthenticated
- [x] Invalid signatures return `401 Unauthorized` with descriptive error
- [x] Expired nonces return `401 Unauthorized` with clear message
- [x] Frontend updated to include signature in API requests
- [x] All existing tests pass (updated to include auth fixtures)