### PR TITLE
infra: add HEALTHCHECK to Dockerfile.windows

### DIFF
--- a/quantara/Dockerfile.windows
+++ b/quantara/Dockerfile.windows
@@ -46,4 +46,7 @@ ADD . /app
 COPY . /app
 RUN dos2unix /app/entrypoint.sh
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
 EXPOSE 8000


### PR DESCRIPTION
## Description

Add `HEALTHCHECK` instruction to `Dockerfile.windows` to match the standard `Dockerfile`. This ensures container orchestration tools can detect unhealthy Windows containers.

## Related Issue

Closes #90

## Change Type

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation
- [ ] refactor — code refactoring
- [ ] test — adding or updating tests
- [x] ci — CI/CD changes

## Testing Done

Linted with `hadolint` — all findings are pre-existing (DL3008, DL4006, DL3020), none introduced by this change. Ran `pylint` on Python files (9.64/10, pre-existing docstring warnings only).

## Screenshots (if UI changes)

N/A

## Checklist

- [x] Tests pass (`poetry run pytest`)
- [x] Code passes linting (`pylint`)
- [ ] Documentation updated (if applicable)
- [x] PR is linked to a related issue