### PR TITLE
feat: implement custom Sentry traces sampler to optimize telemetry da…

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -60,6 +60,19 @@ def get_cors_origins() -> list[str]:
     origins = [origin.strip() for origin in raw_origins.split(",")]
     return [origin for origin in origins if origin] or DEFAULT_CORS_ORIGINS
 
+def custom_traces_sampler(sampling_context):
+    asgi_scope = sampling_context.get("asgi_scope", {})
+    path = asgi_scope.get("path", "")
+    method = asgi_scope.get("method", "")
+
+    if path in ("/api/save-bug-report", "/api/auth/connect"):
+        return 1.0
+    if path == "/health":
+        return 0.005
+    if method in ("POST", "PUT", "PATCH", "DELETE"):
+        return 0.5
+    return 0.05
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -82,7 +95,7 @@ async def lifespan(app: FastAPI):
         import sentry_sdk
         sentry_sdk.init(
             dsn=os.getenv("SENTRY_DSN"),
-            traces_sample_rate=1.0,
+            traces_sampler=custom_traces_sampler,
             _experiments={
                 "continuous_profiling_auto_start": True,
             },


### PR DESCRIPTION
closes #211 
## Title
feat: implement dynamic Sentry traces sampler

## Description
This PR addresses an issue where `traces_sample_rate=1.0` was causing excessively large traces to be generated, particularly during Docker restarts with deeply nested async operations. We have implemented a `traces_sampler` callback to dynamically adjust sampling rates based on the endpoint and HTTP method. 

## Changes Made
- Removed the static `traces_sample_rate=1.0` from `sentry_sdk.init()`.
- Added a `custom_traces_sampler` function to dynamically determine the sample rate from the `asgi_scope`.
- Applied the following sampling policy (narrow exact matches):
  - **1.0 (100%)** for sensitive endpoints: `/api/save-bug-report` and `/api/auth/connect`
  - **0.5 (50%)** for data mutations (`POST`, `PUT`, `PATCH`, `DELETE`)
  - **0.005 (0.5%)** for the `/health` endpoint
  - **0.05 (5%)** as the default fallback for standard reads (`GET`, etc.)

## Acceptance Criteria Met
- [x] Reduced overall trace volume based on endpoint sensitivity.
- [x] Bug report events remain 100% sampled.
- [x] Health checks are properly throttled to <1% sampling.
