### PR TITLE
feat(outbox): implement transactional outbox for Soroban event delive…

### DIFF
--- a/quantara/web_app/alembic/versions/228_add_outbox_event_table.py
+++ b/quantara/web_app/alembic/versions/228_add_outbox_event_table.py
@@ -1,0 +1,35 @@
+"""add outbox event table
+
+Revision ID: outbox_event_table_rev
+Revises: a10b2c3d4e5f
+Create Date: 2026-07-16 14:15:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "outbox_event_table_rev"
+down_revision = "a10b2c3d4e5f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_outbox",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("payload", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("error_message", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("event_outbox")

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -198,15 +198,38 @@ async def open_position(request: Request, position_id: str, transaction_hash: st
     if not transaction_hash:
         raise HTTPException(status_code=400, detail="Transaction hash is required")
 
-    current_prices = await DashboardMixin.get_current_prices()
-    position_status = position_db_connector.open_position(position_id, current_prices)
+    from uuid import UUID
+    import json
+    from web_app.db.models import OutboxEvent, Position
 
-    if transaction_hash:
-        transaction_db_connector.create_transaction(
-            position_id, transaction_hash, status=TransactionStatus.OPENED.value
-        )
+    try:
+        pos_uuid = UUID(position_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid position ID format")
 
-    return position_status
+    position = position_db_connector.get_object(Position, pos_uuid)
+    if not position:
+        raise HTTPException(status_code=404, detail="Position not found")
+
+    payload = json.dumps({
+        "position_id": str(pos_uuid),
+        "transaction_hash": transaction_hash
+    })
+
+    outbox_event = OutboxEvent(
+        event_type="PositionOpened",
+        payload=payload,
+        status="pending",
+        retry_count=0
+    )
+
+    try:
+        position_db_connector.write_to_db(outbox_event)
+    except Exception as e:
+        logger.error("failed_to_write_outbox_event", error=str(e))
+        raise HTTPException(status_code=500, detail="Failed to queue position opening")
+
+    return "pending"
 
 
 @router.get(

--- a/quantara/web_app/db/models.py
+++ b/quantara/web_app/db/models.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Integer,
     String,
     UniqueConstraint,
 )
@@ -225,4 +226,24 @@ class ExtraDeposit(Base):
     position_id = Column(UUID(as_uuid=True), ForeignKey("position.id"))
     __table_args__ = (
         UniqueConstraint("position_id", "token_symbol", name="_position_token_uc"),
+    )
+
+
+class OutboxEvent(Base):
+    """
+    SQLAlchemy model for the event outbox table.
+    Stores events that need to be published or processed asynchronously.
+    """
+
+    __tablename__ = "event_outbox"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    event_type = Column(String, nullable=False)
+    payload = Column(String, nullable=False)  # JSON-serialized payload
+    status = Column(String, nullable=False, default="pending")  # pending, processing, processed, failed
+    retry_count = Column(Integer, nullable=False, default=0)
+    error_message = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
     )

--- a/quantara/web_app/tasks/outbox_relay.py
+++ b/quantara/web_app/tasks/outbox_relay.py
@@ -1,0 +1,182 @@
+"""
+Transactional outbox relay and Celery worker tasks for Soroban event delivery.
+"""
+
+import os
+import asyncio
+import json
+import sentry_sdk
+from datetime import datetime, timedelta
+from celery import Celery
+from sqlalchemy.orm import Session
+from web_app.db.database import SessionLocal, init_db
+from web_app.db.models import OutboxEvent, Position, Status, Transaction, TransactionStatus
+from web_app.db.crud import PositionDBConnector, TransactionDBConnector
+from web_app.contract_tools.mixins import DashboardMixin
+from web_app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+
+# Initialize the Celery application
+celery_app = Celery("outbox_relay", broker=REDIS_URL, backend=REDIS_URL)
+
+# Configure Celery
+celery_app.conf.update(
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    timezone="UTC",
+    enable_utc=True,
+)
+
+
+@celery_app.task(bind=True, max_retries=5, default_retry_delay=10)
+def process_position_opened_task(self, event_id: str):
+    """
+    Celery task that consumes the PositionOpened event from the outbox.
+    """
+    logger.info("processing_position_opened_task_started", event_id=event_id)
+    
+    init_db()
+    db: Session = SessionLocal()
+    try:
+        # 1. Fetch the outbox event
+        event = db.query(OutboxEvent).filter(OutboxEvent.id == event_id).first()
+        if not event:
+            logger.error("outbox_event_not_found", event_id=event_id)
+            return
+
+        # If it's already processed, make it idempotent and do nothing
+        if event.status == "processed":
+            logger.info("outbox_event_already_processed", event_id=event_id)
+            return
+
+        # 2. Parse the payload
+        payload = json.loads(event.payload)
+        position_id = payload.get("position_id")
+        transaction_hash = payload.get("transaction_hash")
+
+        if not position_id or not transaction_hash:
+            raise ValueError(f"Invalid payload for outbox event {event_id}")
+
+        # 3. Connect to DB connectors
+        position_db_connector = PositionDBConnector()
+        transaction_db_connector = TransactionDBConnector()
+
+        # 4. Check idempotency at resource levels
+        position = position_db_connector.get_object(Position, position_id)
+        if not position:
+            raise ValueError(f"Position {position_id} not found for outbox event {event_id}")
+
+        existing_tx = transaction_db_connector.get_object_by_field(
+            Transaction, "transaction_hash", transaction_hash
+        )
+
+        # Retrieve current prices
+        try:
+            # DashboardMixin.get_current_prices is an async function
+            current_prices = asyncio.run(DashboardMixin.get_current_prices())
+        except Exception as e:
+            logger.error("downstream_pricing_api_failed", event_id=event_id, error=str(e))
+            raise e
+
+        # Update position status to OPENED if it's not already opened
+        if position.status != Status.OPENED.value:
+            position_db_connector.open_position(position_id, current_prices)
+            logger.info("position_opened_successfully", position_id=position_id)
+        else:
+            logger.info("position_already_opened_skipping", position_id=position_id)
+
+        # Create Transaction record if it's not already created
+        if not existing_tx:
+            transaction_db_connector.create_transaction(
+                position_id, transaction_hash, status=TransactionStatus.OPENED.value
+            )
+            logger.info("transaction_recorded_successfully", transaction_hash=transaction_hash)
+        else:
+            logger.info("transaction_already_recorded_skipping", transaction_hash=transaction_hash)
+
+        # 5. Mark outbox event as processed
+        event.status = "processed"
+        event.error_message = None
+        db.commit()
+        logger.info("outbox_event_processed_successfully", event_id=event_id)
+
+    except Exception as exc:
+        db.rollback()
+        logger.exception("outbox_event_processing_failed", event_id=event_id, error=str(exc))
+        
+        # Update event status to failed and increment retry
+        try:
+            with SessionLocal() as fail_session:
+                evt = fail_session.query(OutboxEvent).filter(OutboxEvent.id == event_id).first()
+                if evt:
+                    evt.status = "failed"
+                    evt.retry_count += 1
+                    evt.error_message = str(exc)
+                    fail_session.commit()
+        except Exception as update_err:
+            logger.error("failed_to_update_outbox_event_status", error=str(update_err))
+
+        # Re-raise to trigger Celery retry mechanism
+        raise self.retry(exc=exc)
+    finally:
+        db.close()
+
+
+class OutboxRelay:
+    def __init__(self, max_retries: int = 5):
+        self.max_retries = max_retries
+        init_db()
+
+    def process_pending_events(self):
+        """
+        Scans event_outbox for pending/failed events and publishes them to Celery.
+        Also flags events older than 24h with a Sentry warning.
+        """
+        logger.info("outbox_relay_scan_started")
+        db: Session = SessionLocal()
+        try:
+            # Check for events older than 24h that are not processed
+            cutoff_24h_naive = datetime.now() - timedelta(hours=24)
+            
+            old_events = db.query(OutboxEvent).filter(
+                OutboxEvent.status != "processed",
+                OutboxEvent.created_at < cutoff_24h_naive
+            ).all()
+
+            for event in old_events:
+                msg = f"Outbox event {event.id} ({event.event_type}) is older than 24 hours and still not processed."
+                logger.warning("outbox_event_older_than_24h", event_id=str(event.id), created_at=str(event.created_at))
+                sentry_sdk.capture_message(msg, level="warning")
+
+            # Fetch pending or failed events
+            pending_events = db.query(OutboxEvent).filter(
+                OutboxEvent.status.in_(["pending", "failed"]),
+                OutboxEvent.retry_count < self.max_retries
+            ).all()
+
+            if not pending_events:
+                logger.info("no_pending_outbox_events")
+                return
+
+            for event in pending_events:
+                # Mark as processing
+                event.status = "processing"
+                db.commit()
+
+                # Publish to Celery
+                process_position_opened_task.delay(str(event.id))
+                logger.info("published_outbox_event_to_queue", event_id=str(event.id))
+
+        except Exception as e:
+            logger.exception("outbox_relay_scan_failed", error=str(e))
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    relay = OutboxRelay()
+    relay.process_pending_events()

--- a/quantara/web_app/tests/test_outbox.py
+++ b/quantara/web_app/tests/test_outbox.py
@@ -1,0 +1,200 @@
+import uuid
+import json
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from web_app.api.main import app
+from web_app.db.models import OutboxEvent, Position, Transaction
+from web_app.tasks.outbox_relay import OutboxRelay, process_position_opened_task
+
+
+@pytest.mark.anyio
+async def test_open_position_queues_outbox_event(client: TestClient) -> None:
+    position_id = str(uuid.uuid4())
+    transaction_hash = "test_tx_hash"
+    
+    mock_position = MagicMock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "pending"
+    
+    saved_events = []
+    
+    def mock_write(obj):
+        if isinstance(obj, OutboxEvent):
+            saved_events.append(obj)
+        return obj
+
+    with patch("web_app.api.position.PositionDBConnector.get_object", return_value=mock_position) as mock_get, \
+         patch("web_app.api.position.PositionDBConnector.write_to_db", side_effect=mock_write) as mock_write_db:
+        
+        response = client.get(
+            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}"
+        )
+        assert response.status_code == 200
+        assert response.json() == "pending"
+        
+        mock_get.assert_called_once_with(Position, uuid.UUID(position_id))
+        assert len(saved_events) == 1
+        assert saved_events[0].event_type == "PositionOpened"
+        payload = json.loads(saved_events[0].payload)
+        assert payload["position_id"] == position_id
+        assert payload["transaction_hash"] == transaction_hash
+
+
+def test_relay_worker_dispatches_task():
+    mock_event = MagicMock(spec=OutboxEvent)
+    mock_event.id = uuid.uuid4()
+    mock_event.event_type = "PositionOpened"
+    mock_event.payload = "{}"
+    mock_event.status = "pending"
+    mock_event.retry_count = 0
+    mock_event.created_at = datetime.now()
+
+    mock_db = MagicMock()
+    # Query returns old events (empty) then pending events (mock_event)
+    mock_query = MagicMock()
+    mock_db.query.return_value = mock_query
+    mock_filter = MagicMock()
+    mock_query.filter.return_value = mock_filter
+    mock_filter.all.side_effect = [[], [mock_event]]
+
+    with patch("web_app.tasks.outbox_relay.SessionLocal", return_value=mock_db), \
+         patch("web_app.tasks.outbox_relay.process_position_opened_task.delay") as mock_delay, \
+         patch("web_app.tasks.outbox_relay.sentry_sdk.capture_message") as mock_sentry:
+        
+        relay = OutboxRelay(max_retries=5)
+        relay.process_pending_events()
+
+        assert mock_event.status == "processing"
+        mock_delay.assert_called_once_with(str(mock_event.id))
+        mock_db.commit.assert_called()
+
+
+def test_relay_worker_sentry_warning_old_events():
+    mock_event = MagicMock(spec=OutboxEvent)
+    mock_event.id = uuid.uuid4()
+    mock_event.event_type = "PositionOpened"
+    mock_event.status = "pending"
+    mock_event.created_at = datetime.now() - timedelta(hours=25)
+
+    mock_db = MagicMock()
+    mock_query = MagicMock()
+    mock_db.query.return_value = mock_query
+    mock_filter = MagicMock()
+    mock_query.filter.return_value = mock_filter
+    mock_filter.all.side_effect = [[mock_event], []]
+
+    with patch("web_app.tasks.outbox_relay.SessionLocal", return_value=mock_db), \
+         patch("web_app.tasks.outbox_relay.process_position_opened_task.delay"), \
+         patch("web_app.tasks.outbox_relay.sentry_sdk.capture_message") as mock_sentry:
+        
+        relay = OutboxRelay(max_retries=5)
+        relay.process_pending_events()
+
+        mock_sentry.assert_called_once()
+        assert "is older than 24 hours" in mock_sentry.call_args[0][0]
+
+
+def test_process_position_opened_task_success():
+    event_id = str(uuid.uuid4())
+    position_id = str(uuid.uuid4())
+    tx_hash = "test_tx_hash"
+    
+    mock_event = MagicMock(spec=OutboxEvent)
+    mock_event.id = uuid.UUID(event_id)
+    mock_event.event_type = "PositionOpened"
+    mock_event.payload = json.dumps({"position_id": position_id, "transaction_hash": tx_hash})
+    mock_event.status = "pending"
+    
+    mock_position = MagicMock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "pending"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_event
+
+    with patch("web_app.tasks.outbox_relay.SessionLocal", return_value=mock_db), \
+         patch("web_app.tasks.outbox_relay.PositionDBConnector.get_object", return_value=mock_position), \
+         patch("web_app.tasks.outbox_relay.PositionDBConnector.open_position") as mock_open, \
+         patch("web_app.tasks.outbox_relay.TransactionDBConnector.get_object_by_field", return_value=None), \
+         patch("web_app.tasks.outbox_relay.TransactionDBConnector.create_transaction") as mock_create_tx, \
+         patch("web_app.tasks.outbox_relay.asyncio.run", return_value={"XLM": 0.1}):
+
+        process_position_opened_task.run(event_id)
+
+        mock_open.assert_called_once()
+        mock_create_tx.assert_called_once()
+        assert mock_event.status == "processed"
+        mock_db.commit.assert_called()
+
+
+def test_process_position_opened_task_downstream_500():
+    event_id = str(uuid.uuid4())
+    position_id = str(uuid.uuid4())
+    tx_hash = "test_tx_hash"
+    
+    mock_event = MagicMock(spec=OutboxEvent)
+    mock_event.id = uuid.UUID(event_id)
+    mock_event.event_type = "PositionOpened"
+    mock_event.payload = json.dumps({"position_id": position_id, "transaction_hash": tx_hash})
+    mock_event.status = "processing"
+    mock_event.retry_count = 0
+    
+    mock_position = MagicMock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "pending"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_event
+
+    from celery.exceptions import Retry
+    retry_exception = Retry()
+
+    with patch("web_app.tasks.outbox_relay.SessionLocal", return_value=mock_db), \
+         patch("web_app.tasks.outbox_relay.PositionDBConnector.get_object", return_value=mock_position), \
+         patch("web_app.tasks.outbox_relay.TransactionDBConnector.get_object_by_field", return_value=None), \
+         patch("web_app.tasks.outbox_relay.asyncio.run", side_effect=Exception("Simulated downstream 500")), \
+         patch("web_app.tasks.outbox_relay.process_position_opened_task.retry", side_effect=retry_exception) as mock_retry:
+
+        with pytest.raises(Retry):
+            process_position_opened_task.run(event_id)
+
+        assert mock_retry.called
+
+
+def test_process_position_opened_task_idempotency():
+    event_id = str(uuid.uuid4())
+    position_id = str(uuid.uuid4())
+    tx_hash = "test_tx_hash"
+    
+    mock_event = MagicMock(spec=OutboxEvent)
+    mock_event.id = uuid.UUID(event_id)
+    mock_event.event_type = "PositionOpened"
+    mock_event.payload = json.dumps({"position_id": position_id, "transaction_hash": tx_hash})
+    mock_event.status = "pending"
+    
+    mock_position = MagicMock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "opened"
+
+    mock_tx = MagicMock(spec=Transaction)
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_event
+
+    with patch("web_app.tasks.outbox_relay.SessionLocal", return_value=mock_db), \
+         patch("web_app.tasks.outbox_relay.PositionDBConnector.get_object", return_value=mock_position), \
+         patch("web_app.tasks.outbox_relay.PositionDBConnector.open_position") as mock_open, \
+         patch("web_app.tasks.outbox_relay.TransactionDBConnector.get_object_by_field", return_value=mock_tx), \
+         patch("web_app.tasks.outbox_relay.TransactionDBConnector.create_transaction") as mock_create_tx, \
+         patch("web_app.tasks.outbox_relay.asyncio.run", return_value={"XLM": 0.1}):
+
+        process_position_opened_task.run(event_id)
+
+        mock_open.assert_not_called()
+        mock_create_tx.assert_not_called()
+        assert mock_event.status == "processed"
+        mock_db.commit.assert_called()

--- a/quantara/web_app/tests/test_positions.py
+++ b/quantara/web_app/tests/test_positions.py
@@ -17,40 +17,32 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
 from web_app.api.main import app
-from web_app.db.models import TransactionStatus
+from web_app.db.models import Position, TransactionStatus
 from web_app.tests.conftest import dict_to_object
 
 
 @pytest.mark.anyio
 async def test_open_position_success(client: TestClient) -> None:
     """
-    Test for successfully opening a position using a valid position ID.
-    Args:
-        client (TestClient): The test client for the FastAPI application.
-    Returns:
-        None
+    Test for successfully opening a position by queuing an outbox event.
     """
     position_id = str(uuid.uuid4())
     transaction_hash = "valid_transaction_hash"
-    with (
-        patch(
-            "web_app.db.crud.PositionDBConnector.open_position"
-        ) as mock_open_position,
-        patch(
-            "web_app.db.crud.TransactionDBConnector.create_transaction"
-        ) as mock_create_transaction,
-    ):
-        mock_open_position.return_value = "Position successfully opened"
-        mock_create_transaction.return_value = {
-            "position_id": position_id,
-            "transaction_hash": transaction_hash,
-            "status": TransactionStatus.OPENED.value,
-        }
+    
+    mock_position = Mock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "pending"
+
+    with patch(
+        "web_app.api.position.PositionDBConnector.get_object", return_value=mock_position
+    ) as mock_get, patch(
+        "web_app.api.position.PositionDBConnector.write_to_db", return_value=None
+    ) as mock_write:
         response = client.get(
             f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}"
         )
         assert response.is_success
-        assert response.json() == "Position successfully opened"
+        assert response.json() == "pending"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #228

# Description
Implemented a transactional outbox pattern to safely handle Soroban event delivery, specifically for the `PositionOpened` events received via the `/api/open-position` endpoint.

Rather than synchronously calling the pricing API and opening the position when the client's wallet calls `/api/open-position`, we write a pending event to the database in the `event_outbox` table and immediately return `pending` to the caller. This ensures that any downstream failures (e.g. pricing API 500/timeout or temporary database/network disconnects) do not cause event drops.

A background relay worker scans the outbox table for pending or failed events, queues them using Celery, and a background task worker processes them. The consumer logic is made idempotent to prevent duplicates. If processing fails, the event is re-queued/replayed by the relay loop. Sentry warnings are triggered for outbox rows older than 24 hours.

## Key Changes
- **Outbox Model**: Added `OutboxEvent` in `models.py` and generated an Alembic migration script to create the `event_outbox` table.
- **FastAPI Endpoint**: Modified `/api/open-position` to record the `PositionOpened` event to the outbox table and return `"pending"`.
- **Relay Worker & Tasks**: Implemented `outbox_relay.py` containing:
  - Celery config and `process_position_opened_task` (idempotent consumer that handles pricing API calls and opening the position in the DB).
  - `OutboxRelay` scanner that polls pending events, publishes them to Celery, and monitors events older than 24 hours to trigger Sentry warnings.
- **Tests**: Adjusted existing tests to expect `"pending"` and created a comprehensive unit test suite in `test_outbox.py`.
