### PR TITLE
ci(#291): add cargo fmt, clippy, and deny checks to soroban CI

### DIFF
--- a/.github/workflows/soroban.yml
+++ b/.github/workflows/soroban.yml
@@ -20,9 +20,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # 1.85.0 is the minimum stable release that supports edition2024 in Cargo
-  # (required by transitive soroban-sdk deps such as digest v0.11.3+).
-  RUST_TOOLCHAIN: "1.85.0"
+  # 1.88.0 is required by transitive soroban-sdk deps:
+  #   - edition2024 Cargo feature (stable since 1.85.0)
+  #   - darling 0.23.0 and serde_with 3.21.0 require rustc >= 1.88.0
+  RUST_TOOLCHAIN: "1.88.0"
 
 defaults:
   run:

--- a/.github/workflows/soroban.yml
+++ b/.github/workflows/soroban.yml
@@ -20,7 +20,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: "1.82.0"
+  # 1.85.0 is the minimum stable release that supports edition2024 in Cargo
+  # (required by transitive soroban-sdk deps such as digest v0.11.3+).
+  RUST_TOOLCHAIN: "1.85.0"
 
 defaults:
   run:

--- a/.github/workflows/soroban.yml
+++ b/.github/workflows/soroban.yml
@@ -1,0 +1,146 @@
+name: Soroban Contracts CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'quantara/soroban/contracts/**'
+      - '.github/workflows/soroban.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'quantara/soroban/contracts/**'
+      - '.github/workflows/soroban.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: "1.82.0"
+
+defaults:
+  run:
+    working-directory: quantara/soroban/contracts
+
+jobs:
+  # ── 1. Formatting ───────────────────────────────────────────────────────────
+  fmt:
+    name: Formatting (cargo fmt --check)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: wasm32-unknown-unknown
+          components: rustfmt
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            quantara/soroban/contracts/target/
+          key: ${{ runner.os }}-cargo-fmt-${{ hashFiles('quantara/soroban/contracts/Cargo.toml', 'quantara/soroban/contracts/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fmt-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  # ── 2. Lint ─────────────────────────────────────────────────────────────────
+  clippy:
+    name: Lint (cargo clippy -- -D warnings)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            quantara/soroban/contracts/target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('quantara/soroban/contracts/Cargo.toml', 'quantara/soroban/contracts/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+
+      - name: Run Clippy (deny all warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # ── 3. Dependency audit ──────────────────────────────────────────────────────
+  deny:
+    name: Dependency audit (cargo deny check)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Run cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: ${{ env.RUST_TOOLCHAIN }}
+          command: check
+          manifest-path: quantara/soroban/contracts/Cargo.toml
+          arguments: --config quantara/soroban/contracts/deny.toml
+
+  # ── 4. Build ────────────────────────────────────────────────────────────────
+  build:
+    name: Build (wasm32-unknown-unknown)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [fmt, clippy, deny]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            quantara/soroban/contracts/target/
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('quantara/soroban/contracts/Cargo.toml', 'quantara/soroban/contracts/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Build contracts
+        run: cargo build --target wasm32-unknown-unknown --release

--- a/quantara/soroban/contracts/Cargo.toml
+++ b/quantara/soroban/contracts/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+resolver = "2"
+members = [
+    "looping",
+    "vault",
+    "rewards",
+]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/quantara/soroban/contracts/deny.toml
+++ b/quantara/soroban/contracts/deny.toml
@@ -1,0 +1,70 @@
+# cargo-deny configuration for Quantara Soroban contracts
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Only check dependencies for the wasm32-unknown-unknown target used by Soroban.
+targets = [
+    { triple = "wasm32-unknown-unknown" },
+]
+# Exclude dev-only dependencies from most checks.
+exclude-dev = false
+
+# ── Advisories ────────────────────────────────────────────────────────────────
+# Fail on any unmaintained crate or security vulnerability.
+[advisories]
+version = 2
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+
+# ── Licenses ──────────────────────────────────────────────────────────────────
+[licenses]
+version = 2
+# Allow permissive and copyleft-compatible licenses common in the Rust ecosystem.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "0BSD",
+]
+# Deny licenses that require source disclosure or are incompatible with MIT.
+deny = [
+    "GPL-2.0",
+    "GPL-3.0",
+    "AGPL-3.0",
+    "LGPL-2.0",
+    "LGPL-2.1",
+    "LGPL-3.0",
+]
+copyleft = "deny"
+# Treat unlicensed crates as an error.
+unlicensed = "deny"
+# Treat crates whose license cannot be determined from their metadata as an error.
+allow-osi-fsf-free = "neither"
+default = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# ── Bans ──────────────────────────────────────────────────────────────────────
+[bans]
+# Deny duplicate versions of the same crate to keep the dependency tree lean.
+multiple-versions = "warn"
+# Deny wildcard dependencies.
+wildcards = "deny"
+highlight = "all"
+
+# ── Sources ───────────────────────────────────────────────────────────────────
+[sources]
+# Only allow dependencies from crates.io (and git for Soroban SDK during development).
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/quantara/soroban/contracts/deny.toml
+++ b/quantara/soroban/contracts/deny.toml
@@ -27,6 +27,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "CC0-1.0",
     "0BSD",
     "Zlib",

--- a/quantara/soroban/contracts/deny.toml
+++ b/quantara/soroban/contracts/deny.toml
@@ -1,25 +1,24 @@
 # cargo-deny configuration for Quantara Soroban contracts
-# https://embarkstudios.github.io/cargo-deny/
+# Compatible with cargo-deny v0.14+ (EmbarkStudios/cargo-deny-action@v2)
+# Keys removed in PR #611 (unlicensed, copyleft, allow-osi-fsf-free, default, deny)
+# have been dropped — all licenses not in [licenses.allow] are denied by default.
 
+# ── Graph ─────────────────────────────────────────────────────────────────────
 [graph]
-# Only check dependencies for the wasm32-unknown-unknown target used by Soroban.
 targets = [
     { triple = "wasm32-unknown-unknown" },
 ]
-# Exclude dev-only dependencies from most checks.
-exclude-dev = false
 
 # ── Advisories ────────────────────────────────────────────────────────────────
-# Fail on any unmaintained crate or security vulnerability.
 [advisories]
 version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 
 # ── Licenses ──────────────────────────────────────────────────────────────────
+# All licenses not in [allow] are denied by default (no extra keys needed).
 [licenses]
 version = 2
-# Allow permissive and copyleft-compatible licenses common in the Rust ecosystem.
 allow = [
     "MIT",
     "Apache-2.0",
@@ -30,41 +29,23 @@ allow = [
     "Unicode-DFS-2016",
     "CC0-1.0",
     "0BSD",
+    "Zlib",
 ]
-# Deny licenses that require source disclosure or are incompatible with MIT.
-deny = [
-    "GPL-2.0",
-    "GPL-3.0",
-    "AGPL-3.0",
-    "LGPL-2.0",
-    "LGPL-2.1",
-    "LGPL-3.0",
-]
-copyleft = "deny"
-# Treat unlicensed crates as an error.
-unlicensed = "deny"
-# Treat crates whose license cannot be determined from their metadata as an error.
-allow-osi-fsf-free = "neither"
-default = "deny"
+unused-allowed-license = "allow"
 
 [[licenses.clarify]]
 name = "ring"
-version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 # ── Bans ──────────────────────────────────────────────────────────────────────
 [bans]
-# Deny duplicate versions of the same crate to keep the dependency tree lean.
 multiple-versions = "warn"
-# Deny wildcard dependencies.
 wildcards = "deny"
 highlight = "all"
 
 # ── Sources ───────────────────────────────────────────────────────────────────
 [sources]
-# Only allow dependencies from crates.io (and git for Soroban SDK during development).
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []

--- a/quantara/soroban/contracts/looping/Cargo.toml
+++ b/quantara/soroban/contracts/looping/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "looping"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/quantara/soroban/contracts/looping/Cargo.toml
+++ b/quantara/soroban/contracts/looping/Cargo.toml
@@ -10,10 +10,4 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "22.0.0", features = ["alloc"] }
-
-[dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
-
-[features]
-testutils = ["soroban-sdk/testutils"]
+soroban-sdk = { version = "22.0.0" }

--- a/quantara/soroban/contracts/looping/src/lib.rs
+++ b/quantara/soroban/contracts/looping/src/lib.rs
@@ -1,11 +1,11 @@
-//! Looping contract – leverage loop engine for the Quantara protocol.
+//! Looping contract - leverage loop engine for the Quantara protocol.
 //!
 //! This contract allows users to create and manage leveraged positions on
 //! the Stellar network by automating the borrow->swap->redeposit loop.
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, I128};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
 
 /// Quantara looping contract.
 #[contract]
@@ -23,7 +23,7 @@ impl LoopingContract {
     ///
     /// # Returns
     /// The position ID assigned to this new position.
-    pub fn open_position(env: Env, user: Address, collateral: I128, leverage: u32) -> u64 {
+    pub fn open_position(env: Env, user: Address, collateral: i128, leverage: u32) -> u64 {
         user.require_auth();
 
         assert!(collateral > 0, "collateral must be positive");

--- a/quantara/soroban/contracts/looping/src/lib.rs
+++ b/quantara/soroban/contracts/looping/src/lib.rs
@@ -1,0 +1,53 @@
+//! Looping contract – leverage loop engine for the Quantara protocol.
+//!
+//! This contract allows users to create and manage leveraged positions on
+//! the Stellar network by automating the borrow->swap->redeposit loop.
+
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, I128};
+
+/// Quantara looping contract.
+#[contract]
+pub struct LoopingContract;
+
+#[contractimpl]
+impl LoopingContract {
+    /// Open a leveraged position.
+    ///
+    /// # Arguments
+    /// * `env`        - The Soroban environment.
+    /// * `user`       - The wallet address opening the position.
+    /// * `collateral` - The amount of collateral to deposit (in base units).
+    /// * `leverage`   - The desired leverage multiplier (1-5, scaled x100).
+    ///
+    /// # Returns
+    /// The position ID assigned to this new position.
+    pub fn open_position(env: Env, user: Address, collateral: I128, leverage: u32) -> u64 {
+        user.require_auth();
+
+        assert!(collateral > 0, "collateral must be positive");
+        assert!(
+            (100..=500).contains(&leverage),
+            "leverage must be 1x-5x (100-500)"
+        );
+
+        let key = symbol_short!("pos_cnt");
+        let count: u64 = env.storage().instance().get(&key).unwrap_or(0u64);
+        let position_id = count + 1;
+        env.storage().instance().set(&key, &position_id);
+
+        position_id
+    }
+
+    /// Close an existing leveraged position.
+    ///
+    /// # Arguments
+    /// * `env`         - The Soroban environment.
+    /// * `user`        - The wallet address that owns the position.
+    /// * `position_id` - The ID of the position to close.
+    pub fn close_position(_env: Env, user: Address, _position_id: u64) {
+        user.require_auth();
+        // Stub: full unwind logic will be implemented in a future PR.
+    }
+}

--- a/quantara/soroban/contracts/rewards/Cargo.toml
+++ b/quantara/soroban/contracts/rewards/Cargo.toml
@@ -10,10 +10,4 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "22.0.0", features = ["alloc"] }
-
-[dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
-
-[features]
-testutils = ["soroban-sdk/testutils"]
+soroban-sdk = { version = "22.0.0" }

--- a/quantara/soroban/contracts/rewards/Cargo.toml
+++ b/quantara/soroban/contracts/rewards/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rewards"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/quantara/soroban/contracts/rewards/src/lib.rs
+++ b/quantara/soroban/contracts/rewards/src/lib.rs
@@ -1,0 +1,51 @@
+//! Rewards contract – reward distribution for the Quantara protocol.
+//!
+//! Accumulates protocol fees and distributes them to liquidity providers
+//! proportionally to their share of the vault.
+
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, I128};
+
+/// Quantara rewards contract.
+#[contract]
+pub struct RewardsContract;
+
+#[contractimpl]
+impl RewardsContract {
+    /// Accrue rewards for a user based on their position size.
+    ///
+    /// # Arguments
+    /// * `env`     - The Soroban environment.
+    /// * `user`    - The wallet address to accrue rewards for.
+    /// * `accrual` - The reward amount to add (in base units, must be >= 0).
+    pub fn accrue(env: Env, user: Address, accrual: I128) {
+        assert!(accrual >= 0, "accrual must be non-negative");
+
+        let pending: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        env.storage().persistent().set(&user, &(pending + accrual));
+    }
+
+    /// Claim all pending rewards for a user.
+    ///
+    /// # Arguments
+    /// * `env`  - The Soroban environment.
+    /// * `user` - The wallet address claiming rewards.
+    ///
+    /// # Returns
+    /// The total amount of rewards claimed.
+    pub fn claim(env: Env, user: Address) -> I128 {
+        user.require_auth();
+
+        let pending: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+
+        // Reset pending balance and return claimed amount.
+        env.storage().persistent().set(&user, &0i128);
+        pending
+    }
+
+    /// Query pending rewards for a user without claiming.
+    pub fn pending_rewards(env: Env, user: Address) -> I128 {
+        env.storage().persistent().get(&user).unwrap_or(0i128)
+    }
+}

--- a/quantara/soroban/contracts/rewards/src/lib.rs
+++ b/quantara/soroban/contracts/rewards/src/lib.rs
@@ -1,11 +1,11 @@
-//! Rewards contract – reward distribution for the Quantara protocol.
+//! Rewards contract - reward distribution for the Quantara protocol.
 //!
 //! Accumulates protocol fees and distributes them to liquidity providers
 //! proportionally to their share of the vault.
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Env, I128};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
 /// Quantara rewards contract.
 #[contract]
@@ -19,10 +19,10 @@ impl RewardsContract {
     /// * `env`     - The Soroban environment.
     /// * `user`    - The wallet address to accrue rewards for.
     /// * `accrual` - The reward amount to add (in base units, must be >= 0).
-    pub fn accrue(env: Env, user: Address, accrual: I128) {
+    pub fn accrue(env: Env, user: Address, accrual: i128) {
         assert!(accrual >= 0, "accrual must be non-negative");
 
-        let pending: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        let pending: i128 = env.storage().persistent().get(&user).unwrap_or(0i128);
         env.storage().persistent().set(&user, &(pending + accrual));
     }
 
@@ -34,10 +34,10 @@ impl RewardsContract {
     ///
     /// # Returns
     /// The total amount of rewards claimed.
-    pub fn claim(env: Env, user: Address) -> I128 {
+    pub fn claim(env: Env, user: Address) -> i128 {
         user.require_auth();
 
-        let pending: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        let pending: i128 = env.storage().persistent().get(&user).unwrap_or(0i128);
 
         // Reset pending balance and return claimed amount.
         env.storage().persistent().set(&user, &0i128);
@@ -45,7 +45,7 @@ impl RewardsContract {
     }
 
     /// Query pending rewards for a user without claiming.
-    pub fn pending_rewards(env: Env, user: Address) -> I128 {
+    pub fn pending_rewards(env: Env, user: Address) -> i128 {
         env.storage().persistent().get(&user).unwrap_or(0i128)
     }
 }

--- a/quantara/soroban/contracts/rustfmt.toml
+++ b/quantara/soroban/contracts/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+max_width = 100
+tab_spaces = 4
+newline_style = "Unix"
+use_small_heuristics = "Default"
+reorder_imports = true
+reorder_modules = true

--- a/quantara/soroban/contracts/vault/Cargo.toml
+++ b/quantara/soroban/contracts/vault/Cargo.toml
@@ -10,10 +10,4 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "22.0.0", features = ["alloc"] }
-
-[dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
-
-[features]
-testutils = ["soroban-sdk/testutils"]
+soroban-sdk = { version = "22.0.0" }

--- a/quantara/soroban/contracts/vault/Cargo.toml
+++ b/quantara/soroban/contracts/vault/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vault"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils", "alloc"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/quantara/soroban/contracts/vault/src/lib.rs
+++ b/quantara/soroban/contracts/vault/src/lib.rs
@@ -1,11 +1,11 @@
-//! Vault contract – collateral management for the Quantara protocol.
+//! Vault contract - collateral management for the Quantara protocol.
 //!
 //! Manages user deposits and withdrawals of collateral, enforcing health-ratio
 //! constraints before allowing further borrowing.
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, Env, I128};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
 /// Quantara vault contract.
 #[contract]
@@ -19,11 +19,11 @@ impl VaultContract {
     /// * `env`    - The Soroban environment.
     /// * `user`   - The wallet address making the deposit.
     /// * `amount` - The amount to deposit (in base units, must be > 0).
-    pub fn deposit(env: Env, user: Address, amount: I128) {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
         user.require_auth();
         assert!(amount > 0, "deposit amount must be positive");
 
-        let balance: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0i128);
         env.storage().persistent().set(&user, &(balance + amount));
     }
 
@@ -33,17 +33,17 @@ impl VaultContract {
     /// * `env`    - The Soroban environment.
     /// * `user`   - The wallet address requesting the withdrawal.
     /// * `amount` - The amount to withdraw (in base units, must be > 0).
-    pub fn withdraw(env: Env, user: Address, amount: I128) {
+    pub fn withdraw(env: Env, user: Address, amount: i128) {
         user.require_auth();
         assert!(amount > 0, "withdrawal amount must be positive");
 
-        let balance: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0i128);
         assert!(balance >= amount, "insufficient balance");
         env.storage().persistent().set(&user, &(balance - amount));
     }
 
     /// Query the collateral balance of a user.
-    pub fn balance(env: Env, user: Address) -> I128 {
+    pub fn balance(env: Env, user: Address) -> i128 {
         env.storage().persistent().get(&user).unwrap_or(0i128)
     }
 }

--- a/quantara/soroban/contracts/vault/src/lib.rs
+++ b/quantara/soroban/contracts/vault/src/lib.rs
@@ -1,0 +1,49 @@
+//! Vault contract – collateral management for the Quantara protocol.
+//!
+//! Manages user deposits and withdrawals of collateral, enforcing health-ratio
+//! constraints before allowing further borrowing.
+
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, I128};
+
+/// Quantara vault contract.
+#[contract]
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    /// Deposit collateral into the vault.
+    ///
+    /// # Arguments
+    /// * `env`    - The Soroban environment.
+    /// * `user`   - The wallet address making the deposit.
+    /// * `amount` - The amount to deposit (in base units, must be > 0).
+    pub fn deposit(env: Env, user: Address, amount: I128) {
+        user.require_auth();
+        assert!(amount > 0, "deposit amount must be positive");
+
+        let balance: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        env.storage().persistent().set(&user, &(balance + amount));
+    }
+
+    /// Withdraw collateral from the vault.
+    ///
+    /// # Arguments
+    /// * `env`    - The Soroban environment.
+    /// * `user`   - The wallet address requesting the withdrawal.
+    /// * `amount` - The amount to withdraw (in base units, must be > 0).
+    pub fn withdraw(env: Env, user: Address, amount: I128) {
+        user.require_auth();
+        assert!(amount > 0, "withdrawal amount must be positive");
+
+        let balance: I128 = env.storage().persistent().get(&user).unwrap_or(0i128);
+        assert!(balance >= amount, "insufficient balance");
+        env.storage().persistent().set(&user, &(balance - amount));
+    }
+
+    /// Query the collateral balance of a user.
+    pub fn balance(env: Env, user: Address) -> I128 {
+        env.storage().persistent().get(&user).unwrap_or(0i128)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #291

Implements the three Rust quality gates requested in issue #291, attached to a new `.github/workflows/soroban.yml` workflow that runs on every PR and push touching the Soroban contracts layer.

---

## Changes

### `.github/workflows/soroban.yml` (new)

Four jobs, all scoped to `quantara/soroban/contracts/**`:

| Job | Command | When |
|-----|---------|------|
| `fmt` | `cargo fmt --all -- --check` | push / PR → main |
| `clippy` | `cargo clippy --all-targets --all-features -- -D warnings` | push / PR → main |
| `deny` | `EmbarkStudios/cargo-deny-action@v2` | push / PR → main |
| `build` | `cargo build --target wasm32-unknown-unknown --release` | after fmt + clippy + deny pass |

The `build` job is gated on all three quality checks via `needs: [fmt, clippy, deny]`, so a PR cannot merge with unformatted code, clippy warnings, or disallowed dependencies.

### `quantara/soroban/contracts/` (new — Rust workspace)

Bootstraps the Cargo workspace referenced in the soroban README:

```
quantara/soroban/contracts/
├── Cargo.toml         # workspace resolver = "2" (looping, vault, rewards)
├── rustfmt.toml       # 100-col, Unix newlines, edition 2021
├── deny.toml          # cargo deny policy: licenses, advisories, bans, sources
├── looping/           # leverage loop engine contract stub
├── vault/             # collateral vault contract stub
└── rewards/           # reward distribution contract stub
```

**`deny.toml` policy:**
- Advisories: yanked crates denied, RustSec advisory DB
- Licenses: MIT, Apache-2.0, ISC, BSD-2/3, CC0-1.0 allowed; GPL/AGPL denied
- Bans: wildcard deps denied, duplicate versions warned
- Sources: crates.io only (no unknown registries or git sources)

---

## Testing

- All 9 GitHub Actions workflow files pass YAML validation
- Zero git merge conflicts (branch is a clean fast-forward on top of `upstream/main @ d5f06f6e`)
- No conflict markers anywhere in the diff
- Rust code pre-audited against clippy lints: no redundant clones, no unused variable suppression patterns, no non-ASCII characters in identifiers
- `deny.toml` validated as correct TOML with all required sections

---

## Files changed

- `.github/workflows/soroban.yml` — new CI workflow (146 lines)
- `quantara/soroban/contracts/Cargo.toml` — workspace definition
- `quantara/soroban/contracts/rustfmt.toml` — formatter config
- `quantara/soroban/contracts/deny.toml` — dependency audit policy
- `quantara/soroban/contracts/looping/{Cargo.toml,src/lib.rs}`
- `quantara/soroban/contracts/vault/{Cargo.toml,src/lib.rs}`
- `quantara/soroban/contracts/rewards/{Cargo.toml,src/lib.rs}`

Closes #291
