### PR TITLE
Add protocol pause controls

### DIFF
--- a/common/pausable.rs
+++ b/common/pausable.rs
@@ -1,0 +1,55 @@
+#![no_std]
+
+use soroban_sdk::{Address, Env, Symbol};
+
+const PAUSED: Symbol = Symbol::short("paused");
+const ADMIN: Symbol = Symbol::short("admin");
+
+pub trait Pausable {
+    fn pause(env: Env);
+    fn unpause(env: Env);
+    fn paused(env: Env) -> bool;
+}
+
+pub fn init_admin(env: &Env, admin: &Address) {
+    if env.storage().instance().has(&ADMIN) {
+        return;
+    }
+
+    env.storage().instance().set(&ADMIN, admin);
+    env.storage().instance().set(&PAUSED, &false);
+}
+
+pub fn pause(env: &Env, caller: &Address) {
+    require_admin(env, caller);
+    env.storage().instance().set(&PAUSED, &true);
+}
+
+pub fn unpause(env: &Env, caller: &Address) {
+    require_admin(env, caller);
+    env.storage().instance().set(&PAUSED, &false);
+}
+
+pub fn paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+
+pub fn require_not_paused(env: &Env) {
+    if paused(env) {
+        panic!("Protocol paused");
+    }
+}
+
+pub fn require_admin(env: &Env, caller: &Address) {
+    caller.require_auth();
+
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&ADMIN)
+        .expect("admin not initialized");
+
+    if admin != *caller {
+        panic!("admin required");
+    }
+}

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -32,6 +32,8 @@ from web_app.api.leaderboard import router as leaderboard_router
 from web_app.api.referal import router as referal_router
 from web_app.api.wallet_auth import router as auth_router
 from web_app.api.metrics import router as metrics_router, PrometheusMiddleware
+from web_app.api.pausable import protocol_pause_middleware
+from web_app.api.pausable import router as pausable_router
 from web_app.config_validator import assert_valid_config
 from web_app.api.middleware import MaxBodySizeMiddleware, SecurityHeadersMiddleware
 from web_app.db.database import init_db
@@ -163,6 +165,9 @@ async def request_id_middleware(request: Request, call_next):
         return response
 
 
+app.middleware("http")(protocol_pause_middleware)
+
+
 @app.get("/health", tags=["Health"], summary="Health check endpoint")
 async def health_check(response: Response, db: Session = Depends(get_database)):
     """Returns 200 OK when the service is running and dependencies are healthy."""
@@ -211,3 +216,4 @@ app.include_router(leaderboard_router)
 app.include_router(referal_router)
 app.include_router(auth_router)
 app.include_router(metrics_router)
+app.include_router(pausable_router)

--- a/quantara/web_app/api/pausable.py
+++ b/quantara/web_app/api/pausable.py
@@ -1,0 +1,99 @@
+"""
+Admin pause controls and request guard for incident response.
+"""
+
+import os
+from dataclasses import dataclass
+from threading import Lock
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+
+PROTOCOL_PAUSED_DETAIL = "Protocol paused"
+ADMIN_PAUSE_PREFIX = "/api/admin/pause"
+PAUSE_ADMIN_TOKEN_ENV = "PAUSE_ADMIN_TOKEN"
+
+
+@dataclass(frozen=True)
+class PauseStatus:
+    paused: bool
+
+
+class PauseController:
+    """Thread-safe in-process protocol pause switch."""
+
+    def __init__(self) -> None:
+        self._paused = False
+        self._lock = Lock()
+
+    def pause(self) -> PauseStatus:
+        with self._lock:
+            self._paused = True
+            return PauseStatus(paused=self._paused)
+
+    def unpause(self) -> PauseStatus:
+        with self._lock:
+            self._paused = False
+            return PauseStatus(paused=self._paused)
+
+    def status(self) -> PauseStatus:
+        with self._lock:
+            return PauseStatus(paused=self._paused)
+
+
+pause_controller = PauseController()
+router = APIRouter(prefix=ADMIN_PAUSE_PREFIX, tags=["Admin"])
+
+
+def _admin_token() -> str | None:
+    return os.getenv(PAUSE_ADMIN_TOKEN_ENV) or os.getenv("ADMIN_API_KEY")
+
+
+def verify_admin_token(x_admin_token: str = Header(...)) -> None:
+    expected_token = _admin_token()
+    if not expected_token or x_admin_token != expected_token:
+        raise HTTPException(status_code=403, detail="Admin authorization required")
+
+
+def is_pause_exempt_path(path: str) -> bool:
+    return (
+        path.startswith(ADMIN_PAUSE_PREFIX)
+        or path == "/health"
+        or path.startswith("/metrics")
+    )
+
+
+async def protocol_pause_middleware(request: Request, call_next):
+    if (
+        request.url.path.startswith("/api/")
+        and not is_pause_exempt_path(request.url.path)
+        and pause_controller.status().paused
+    ):
+        return JSONResponse(status_code=503, content={"detail": PROTOCOL_PAUSED_DETAIL})
+
+    return await call_next(request)
+
+
+@router.get("", summary="Get protocol pause status")
+async def get_pause_status(
+    x_admin_token: str = Header(..., alias="X-Admin-Token"),
+) -> dict:
+    verify_admin_token(x_admin_token)
+    return {"paused": pause_controller.status().paused}
+
+
+@router.post("", summary="Pause protocol user-facing operations")
+async def pause_protocol(
+    x_admin_token: str = Header(..., alias="X-Admin-Token"),
+) -> dict:
+    verify_admin_token(x_admin_token)
+    return {"paused": pause_controller.pause().paused}
+
+
+@router.delete("", summary="Unpause protocol user-facing operations")
+async def unpause_protocol(
+    x_admin_token: str = Header(..., alias="X-Admin-Token"),
+) -> dict:
+    verify_admin_token(x_admin_token)
+    return {"paused": pause_controller.unpause().paused}

--- a/quantara/web_app/tests/test_pausable.py
+++ b/quantara/web_app/tests/test_pausable.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from web_app.api.main import app
+from web_app.api.pausable import pause_controller
+from web_app.db.database import get_database
+
+
+ADMIN_HEADERS = {"X-Admin-Token": "test-admin-token"}
+
+
+def test_admin_can_pause_and_unpause_protocol(monkeypatch):
+    monkeypatch.setenv("PAUSE_ADMIN_TOKEN", "test-admin-token")
+    pause_controller.unpause()
+    app.dependency_overrides[get_database] = lambda: MagicMock()
+    client = TestClient(app)
+
+    assert client.get("/api/admin/pause", headers=ADMIN_HEADERS).json() == {
+        "paused": False
+    }
+
+    pause_response = client.post("/api/admin/pause", headers=ADMIN_HEADERS)
+    assert pause_response.status_code == 200
+    assert pause_response.json() == {"paused": True}
+
+    blocked_response = client.get("/api/check-user?wallet_id=test-wallet")
+    assert blocked_response.status_code == 503
+    assert blocked_response.json() == {"detail": "Protocol paused"}
+
+    unpause_response = client.delete("/api/admin/pause", headers=ADMIN_HEADERS)
+    assert unpause_response.status_code == 200
+    assert unpause_response.json() == {"paused": False}
+
+    app.dependency_overrides.clear()
+
+
+def test_pause_admin_requires_token(monkeypatch):
+    monkeypatch.setenv("PAUSE_ADMIN_TOKEN", "test-admin-token")
+    pause_controller.unpause()
+    client = TestClient(app)
+
+    response = client.post("/api/admin/pause", headers={"X-Admin-Token": "wrong"})
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin authorization required"}


### PR DESCRIPTION
## Description

Adds protocol pause/unpause controls for incident response. Admins can pause user-facing API operations so users receive `Protocol paused`, while admin pause/unpause and health/metrics paths remain available. Also adds a reusable Soroban-style `Pausable` helper module.

## Related Issue

Closes #246

## Change Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation
- [ ] refactor — code refactoring
- [x] test — adding or updating tests
- [ ] ci — CI/CD changes

## Testing Done

- Syntax checked changed Python files with `python -c` AST parsing.
- Attempted targeted pytest run, but local environment is missing `poetry` and `pytest`.

## Screenshots (if UI changes)

None

## Environment Variables

Adds `PAUSE_ADMIN_TOKEN` for admin pause/unpause authorization. Falls back to `ADMIN_API_KEY` if unset.

## Checklist

- [ ] `make lint` passes (pylint on changed `.py` files)
- [ ] `make test` passes (pytest in `quantara/web_app/tests/`)
- [ ] CI is green on this PR
- [ ] Documentation updated (if applicable)
- [x] PR is linked to a related issue (`Closes #246`)