### PR TITLE
ci: add release-please workflow for conventional commits (#288)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple


### PR DESCRIPTION
## Summary

Adds a release-please workflow that runs on push to main. This enables conventional commits and auto-generates CHANGELOG files.

## Changes

- New `.github/workflows/release-please.yml` workflow using `googleapis/release-please-action@v4`
- Configured with `release-type: simple` for standard release notes

## Testing

- [x] Workflow syntax validated
- [x] No breaking changes to existing workflows

## Checklist

- [x] Code compiles without errors
- [x] No breaking changes
- [x] Documentation updated if needed

Closes #288