### PR TITLE
security: add deep-link replay protection (#281)

### DIFF
--- a/quantara/web_app/telegram/handlers/command.py
+++ b/quantara/web_app/telegram/handlers/command.py
@@ -13,6 +13,7 @@ from ..markups import launch_main_web_app_kb
 from ..texts import i18n
 from web_app.db.crud.telegram import TelegramUserDBConnector
 from web_app.db.crud import DBConnector
+from ..nonce_store import nonce_store
 
 # Create a router for handling commands
 cmd_router = Router()
@@ -24,22 +25,32 @@ db_connector = DBConnector()
 @cmd_router.message(CommandStart(deep_link=True, deep_link_encoded=True))
 async def notification_allowed(message: Message, command: CommandObject):
     """
-    Handle the /start command with user id parameter.
+    Handle the /start command with user id and nonce parameter.
 
     Args:
         message (Message): The incoming message containing the command.
-        command (CommandObject): The command object containing the user id.
+        command (CommandObject): The command object containing "user_id:nonce".
     """
-    user_id = command.args
-    user = db_connector.get_object(User, user_id)
-    telegram_db.update_telegram_user(
-        str(message.from_user.id), dict(wallet_id=user.wallet_id)
-    )
-    telegram_db.set_allow_notification(str(message.from_user.id), user.wallet_id)
+    raw_args = command.args or ""
+    parts = raw_args.split(":", 1)
+
+    if len(parts) != 2:
+        return await message.answer("Invalid link.")
+
+    user_id_str, nonce = parts
+    tg_user_id = str(message.from_user.id)
+
+    if not nonce_store.validate(nonce, user_id_str):
+        return await message.answer("Link expired or already used.")
+
+    user = db_connector.get_object(User, int(user_id_str))
+    telegram_db.update_telegram_user(tg_user_id, dict(wallet_id=user.wallet_id))
+    telegram_db.set_allow_notification(tg_user_id, user.wallet_id)
 
     lang = getattr(message.from_user, "language_code", None) or "en"
     return await message.answer(
-        i18n.get("NOTIFICATION_ALLOWED_MESSAGE", lang), reply_markup=launch_main_web_app_kb
+        i18n.get("NOTIFICATION_ALLOWED_MESSAGE", lang),
+        reply_markup=launch_main_web_app_kb,
     )
 
 

--- a/quantara/web_app/telegram/markups.py
+++ b/quantara/web_app/telegram/markups.py
@@ -1,15 +1,39 @@
 """
 This module defines the inline keyboard markup used in the Telegram bot.
 
-It includes the keyboard for launching the main web application.
+It includes the keyboard for launching the main web application
+and a helper to build deep links with replay-protected nonces.
 """
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    WebAppInfo,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 
 from .config import WEBAPP_URL
+from .nonce_store import nonce_store
+
 
 launch_main_web_app_kb = InlineKeyboardMarkup(
     inline_keyboard=[
         [InlineKeyboardButton(text="Launch app", web_app=WebAppInfo(url=WEBAPP_URL))]
     ]
 )
+
+
+def build_notification_deep_link(user_id: int, bot_username: str) -> tuple[str, str]:
+    """Build a /start deep link URL with a signed nonce.
+
+    Args:
+        user_id: The numeric Telegram user id to bind.
+        bot_username: The bot's Telegram username (without @).
+
+    Returns:
+        A tuple of (deep_link_url, nonce). The nonce is stored server-side
+        and must be validated on receipt.
+    """
+    nonce = nonce_store.generate(str(user_id))
+    return f"https://t.me/{bot_username}?start={user_id}:{nonce}", nonce

--- a/quantara/web_app/telegram/nonce_store.py
+++ b/quantara/web_app/telegram/nonce_store.py
@@ -1,0 +1,68 @@
+"""
+This module provides nonce generation and validation for deep-link replay protection.
+
+Nonces are stored in-memory with a configurable TTL (default 5 minutes).
+Each nonce is single-use and deleted after successful validation.
+"""
+
+import time
+from typing import Optional
+
+import secrets
+
+NONCE_TTL_SECONDS = 300  # 5 minutes
+
+
+class NonceStore:
+    """In-memory nonce store with TTL-based expiry."""
+
+    def __init__(self, ttl: int = NONCE_TTL_SECONDS):
+        self._store: dict[str, tuple[str, float]] = {}
+        self._ttl = ttl
+
+    def generate(self, user_id: str) -> str:
+        """Generate a nonce for the given user_id and store it.
+
+        Returns the generated nonce string.
+        """
+        nonce = secrets.token_urlsafe(32)
+        self._store[nonce] = (user_id, time.time())
+        return nonce
+
+    def validate(self, nonce: str, expected_user_id: str) -> bool:
+        """Validate a nonce.
+
+        - Checks the nonce exists
+        - Checks the user_id matches
+        - Checks the TTL has not expired
+        - Deletes the nonce after successful validation (single-use)
+
+        Returns True if valid, False otherwise.
+        """
+        entry = self._store.pop(nonce, None)
+        if entry is None:
+            return False
+
+        stored_user_id, created_at = entry
+        if stored_user_id != expected_user_id:
+            return False
+
+        if time.time() - created_at > self._ttl:
+            return False
+
+        return True
+
+    def cleanup_expired(self) -> int:
+        """Remove expired nonces. Returns the number of entries removed."""
+        now = time.time()
+        expired = [
+            k for k, (_, created_at) in self._store.items()
+            if now - created_at > self._ttl
+        ]
+        for k in expired:
+            del self._store[k]
+        return len(expired)
+
+
+# Singleton instance used by the app
+nonce_store = NonceStore()

--- a/quantara/web_app/tests/test_telegram.py
+++ b/quantara/web_app/tests/test_telegram.py
@@ -251,12 +251,13 @@ class TestCommandHandlers:
         command.telegram_db.set_allow_notification = MagicMock(return_value=None)
 
         msg = self._fake_message()
-        cmd_obj = SimpleNamespace(args="USER-123")
+        cmd_obj = SimpleNamespace(args="42:fake-nonce-value")
 
-        await command.notification_allowed(msg, cmd_obj)
+        with patch.object(command.nonce_store, "validate", return_value=True):
+            await command.notification_allowed(msg, cmd_obj)
 
         command.db_connector.get_object.assert_called_once_with(
-            User, "USER-123",
+            User, 42,
         )
         command.telegram_db.update_telegram_user.assert_called_once_with(
             "999", {"wallet_id": "WALLET-XYZ"},


### PR DESCRIPTION
## Summary
Adds nonce-based replay protection to the Telegram /start deep link flow to prevent wallet-linking replay attacks.

## Changes
- **New file: nonce_store.py** - In-memory nonce store with 5-minute TTL. Uses secrets.token_urlsafe(32) for nonce generation. Single-use nonces deleted after validation.
- **Modified: command.py** - Parses user_id:nonce from /start args, validates nonce via nonce_store, and returns error for invalid/expired/already-used links.
- **Modified: markups.py** - Added build_notification_deep_link() helper that generates a deep link URL with an embedded nonce.

## Security
- An attacker replaying a stale /start link will be rejected (nonce expired or already consumed).
- Nonces are single-use: after successful validation they are deleted from the store.
- The 5-minute TTL limits the window for any attempted replay.

Closes #281
