### PR TITLE
feat(telegram): add admin incident commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
 # [Optional] Telegram Bot API Token (e.g. from BotFather)
 TELEGRAM_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ
+TELEGRAM_ADMIN_USER_IDS=123456789,987654321
 
 # [Optional] URL for the Telegram WebApp / Mini-App (default: https://quantara.xyz)
 TELEGRAM_WEBAPP_URL=https://quantara.xyz

--- a/quantara/web_app/db/crud/telegram.py
+++ b/quantara/web_app/db/crud/telegram.py
@@ -6,6 +6,7 @@ import logging
 from typing import TypeVar
 
 from sqlalchemy import update
+from sqlalchemy.exc import SQLAlchemyError
 
 from web_app.db.models import Base, TelegramUser
 
@@ -107,3 +108,18 @@ class TelegramUserDBConnector(DBConnector):
             )
         )
         return True
+
+    def get_notification_recipients(self) -> list[str]:
+        """Return all Telegram IDs that opted in to notifications."""
+        with self.Session() as session:
+            try:
+                rows = (
+                    session.query(TelegramUser.telegram_id)
+                    .filter(TelegramUser.is_allowed_notification.is_(True))
+                    .distinct()
+                    .all()
+                )
+                return [telegram_id for (telegram_id,) in rows]
+            except SQLAlchemyError as exc:
+                logger.error("Failed to load Telegram notification recipients: %s", exc)
+                return []

--- a/quantara/web_app/telegram/__init__.py
+++ b/quantara/web_app/telegram/__init__.py
@@ -4,11 +4,12 @@ This module initializes the Telegram bot and sets up the dispatcher for handling
 It imports necessary components from the aiogram library and configures logging.
 """
 
-from aiogram import Bot, Dispatcher
 import logging
 
+from aiogram import Bot, Dispatcher
+
 from .config import TELEGRAM_TOKEN
-from .handlers import cmd_router
+from .handlers import admin_router, cmd_router
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -27,4 +28,4 @@ else:
 # Create a Dispatcher for handling updates
 dp = Dispatcher()
 # Include command routers for handling specific commands
-dp.include_routers(cmd_router)
+dp.include_routers(cmd_router, admin_router)

--- a/quantara/web_app/telegram/config.py
+++ b/quantara/web_app/telegram/config.py
@@ -13,3 +13,20 @@ load_dotenv()
 # Retrieve the Telegram bot token from environment variables
 TELEGRAM_TOKEN = getenv("TELEGRAM_TOKEN")
 WEBAPP_URL = getenv("TELEGRAM_WEBAPP_URL", "https://quantara.xyz")
+
+
+def parse_admin_ids(value: str) -> frozenset[int]:
+    """Parse a comma-separated Telegram user ID allowlist."""
+    admin_ids: set[int] = set()
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            admin_ids.add(int(item))
+        except ValueError:
+            continue
+    return frozenset(admin_ids)
+
+
+TELEGRAM_ADMIN_USER_IDS = parse_admin_ids(getenv("TELEGRAM_ADMIN_USER_IDS", ""))

--- a/quantara/web_app/telegram/handlers/__init__.py
+++ b/quantara/web_app/telegram/handlers/__init__.py
@@ -4,6 +4,7 @@ This module imports command routers for handling commands in the Telegram bot.
 It serves as an entry point for the command handling functionality.
 """
 
+from .admin import admin_router
 from .command import cmd_router
 
 # Import command router for handling commands in the bot

--- a/quantara/web_app/telegram/handlers/admin.py
+++ b/quantara/web_app/telegram/handlers/admin.py
@@ -1,0 +1,242 @@
+"""Administrative Telegram commands for incident response."""
+
+import asyncio
+import logging
+import os
+import secrets
+import time
+
+import redis.asyncio as redis
+from aiogram import F, Router
+from aiogram.filters import Command, CommandObject
+from aiogram.types import (
+    CallbackQuery,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+)
+
+from web_app.db.crud.telegram import TelegramUserDBConnector
+from web_app.telegram.config import TELEGRAM_ADMIN_USER_IDS
+
+logger = logging.getLogger(__name__)
+
+admin_router = Router()
+telegram_db = TelegramUserDBConnector()
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+BROADCAST_RATE_LIMIT_SECONDS = 60 * 60
+BROADCAST_CONFIRM_TTL_SECONDS = 10 * 60
+HEALTH_REDIS_TIMEOUT_SECONDS = 1.5
+NOTIFICATION_PAUSE_KEY = "quantara:telegram:notifications:paused"
+BROADCAST_RATE_KEY_PREFIX = "quantara:telegram:admin:broadcast:rate"
+BROADCAST_PENDING_KEY_PREFIX = "quantara:telegram:admin:broadcast:pending"
+BOT_STARTED_AT = time.monotonic()
+
+_redis_client: redis.Redis | None = None
+
+
+def get_redis_client() -> redis.Redis:
+    """Return the lazily initialized shared Redis client."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+def _is_admin(user) -> bool:
+    """Return whether an aiogram user is in the configured admin allowlist."""
+    return bool(user and user.id in TELEGRAM_ADMIN_USER_IDS)
+
+
+async def _reject_unauthorized(event: Message | CallbackQuery) -> bool:
+    """Reply to unauthorized callers and report whether processing must stop."""
+    if _is_admin(event.from_user):
+        return False
+    if isinstance(event, CallbackQuery):
+        await event.answer("Admin authorization required.", show_alert=True)
+    else:
+        await event.answer("Admin authorization required.")
+    return True
+
+
+def _rate_key(admin_id: int) -> str:
+    """Build the per-admin hourly broadcast rate-limit key."""
+    return f"{BROADCAST_RATE_KEY_PREFIX}:{admin_id}"
+
+
+def _pending_key(admin_id: int, nonce: str) -> str:
+    """Build the key for a broadcast awaiting confirmation."""
+    return f"{BROADCAST_PENDING_KEY_PREFIX}:{admin_id}:{nonce}"
+
+
+async def notifications_are_paused() -> bool:
+    """Return whether alert delivery is globally paused, failing open on Redis errors."""
+    try:
+        return bool(await get_redis_client().exists(NOTIFICATION_PAUSE_KEY))
+    except Exception as exc:
+        logger.error("Unable to read Telegram pause state: %s", exc)
+        return False
+
+
+@admin_router.message(
+    Command("broadcast"), F.from_user.func(lambda user: _is_admin(user))
+)
+async def broadcast_cmd(message: Message, command: CommandObject) -> None:
+    """Stage a broadcast and ask the administrator for confirmation."""
+    if await _reject_unauthorized(message):
+        return
+
+    text = (command.args or "").strip()
+    if not text:
+        await message.answer("Usage: /broadcast <message>")
+        return
+
+    client = get_redis_client()
+    remaining = await client.ttl(_rate_key(message.from_user.id))
+    if remaining > 0:
+        await message.answer(
+            f"Broadcast rate limit active. Try again in {remaining} seconds."
+        )
+        return
+
+    nonce = secrets.token_urlsafe(8)
+    await client.setex(
+        _pending_key(message.from_user.id, nonce),
+        BROADCAST_CONFIRM_TTL_SECONDS,
+        text,
+    )
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Confirm broadcast",
+                    callback_data=f"admin:broadcast:confirm:{nonce}",
+                ),
+                InlineKeyboardButton(
+                    text="Cancel",
+                    callback_data=f"admin:broadcast:cancel:{nonce}",
+                ),
+            ]
+        ]
+    )
+    await message.answer(
+        f"Broadcast this message to all opted-in users?\n\n{text}",
+        reply_markup=keyboard,
+    )
+
+
+async def _send_broadcast(bot, recipients: list[str], text: str) -> tuple[int, int]:
+    """Send a bounded-concurrency broadcast and return sent/failed counts."""
+    semaphore = asyncio.Semaphore(20)
+
+    async def send(telegram_id: str) -> bool:
+        """Send to one recipient without aborting the remaining broadcast."""
+        async with semaphore:
+            try:
+                await bot.send_message(chat_id=telegram_id, text=text)
+                return True
+            except Exception as exc:
+                logger.warning("Broadcast delivery failed for %s: %s", telegram_id, exc)
+                return False
+
+    results = await asyncio.gather(*(send(telegram_id) for telegram_id in recipients))
+    sent = sum(results)
+    return sent, len(results) - sent
+
+
+@admin_router.callback_query(
+    F.data.startswith("admin:broadcast:confirm:"),
+    F.from_user.func(lambda user: _is_admin(user)),
+)
+async def confirm_broadcast(callback: CallbackQuery) -> None:
+    """Send a staged broadcast after atomically acquiring the hourly limit."""
+    if await _reject_unauthorized(callback):
+        return
+
+    nonce = callback.data.rsplit(":", 1)[-1]
+    client = get_redis_client()
+    pending_key = _pending_key(callback.from_user.id, nonce)
+    text = await client.get(pending_key)
+    if text is None:
+        await callback.answer("This confirmation expired.", show_alert=True)
+        return
+
+    acquired = await client.set(
+        _rate_key(callback.from_user.id),
+        "1",
+        ex=BROADCAST_RATE_LIMIT_SECONDS,
+        nx=True,
+    )
+    if not acquired:
+        await callback.answer("Broadcast rate limit active.", show_alert=True)
+        return
+
+    await client.delete(pending_key)
+    await callback.answer("Broadcast started.")
+    recipients = await asyncio.to_thread(telegram_db.get_notification_recipients)
+    sent, failed = await _send_broadcast(callback.bot, recipients, text)
+    await callback.message.edit_text(
+        f"Broadcast complete: {sent} sent, {failed} failed."
+    )
+
+
+@admin_router.callback_query(
+    F.data.startswith("admin:broadcast:cancel:"),
+    F.from_user.func(lambda user: _is_admin(user)),
+)
+async def cancel_broadcast(callback: CallbackQuery) -> None:
+    """Discard a staged broadcast."""
+    if await _reject_unauthorized(callback):
+        return
+
+    nonce = callback.data.rsplit(":", 1)[-1]
+    await get_redis_client().delete(_pending_key(callback.from_user.id, nonce))
+    await callback.answer("Broadcast cancelled.")
+    await callback.message.edit_text("Broadcast cancelled.")
+
+
+@admin_router.message(Command("pause"), F.from_user.func(lambda user: _is_admin(user)))
+async def pause_cmd(message: Message, command: CommandObject) -> None:
+    """Pause Telegram alert delivery for the requested number of minutes."""
+    if await _reject_unauthorized(message):
+        return
+
+    try:
+        minutes = int((command.args or "").strip())
+    except ValueError:
+        minutes = 0
+    if minutes <= 0:
+        await message.answer("Usage: /pause <positive minutes>")
+        return
+
+    seconds = minutes * 60
+    await get_redis_client().set(
+        NOTIFICATION_PAUSE_KEY,
+        str(message.from_user.id),
+        ex=seconds,
+    )
+    await message.answer(f"Notifications paused for {minutes} minute(s).")
+
+
+@admin_router.message(Command("health"), F.from_user.func(lambda user: _is_admin(user)))
+async def health_cmd(message: Message) -> None:
+    """Report bot uptime and bounded Redis ping latency."""
+    if await _reject_unauthorized(message):
+        return
+
+    started = time.perf_counter()
+    try:
+        await asyncio.wait_for(
+            get_redis_client().ping(), timeout=HEALTH_REDIS_TIMEOUT_SECONDS
+        )
+        redis_status = "up"
+    except TimeoutError:
+        redis_status = "timeout"
+    except Exception:
+        redis_status = "down"
+    latency_ms = (time.perf_counter() - started) * 1_000
+    uptime_seconds = int(time.monotonic() - BOT_STARTED_AT)
+    await message.answer(
+        f"Bot uptime: {uptime_seconds}s\n" f"Redis: {redis_status} ({latency_ms:.1f}ms)"
+    )

--- a/quantara/web_app/telegram/notifications.py
+++ b/quantara/web_app/telegram/notifications.py
@@ -7,10 +7,12 @@ import logging
 from decimal import Decimal
 
 from aiogram.exceptions import TelegramRetryAfter
+
 from web_app.db.crud import TelegramUserDBConnector
 from web_app.telegram import bot
 
 from .dedupe import NotificationDedupe
+from .handlers.admin import notifications_are_paused
 from .texts import i18n
 
 logger = logging.getLogger(__name__)
@@ -32,6 +34,12 @@ async def send_health_ratio_notification(
     Send notification about health ratio to user.
     Deduplication prevents repeated alerts for the same user/position within 4h.
     """
+    if await notifications_are_paused():
+        logger.info(
+            "Telegram alerts are paused; skipping notification to %s", telegram_id
+        )
+        return
+
     if position_id and not await dedupe.should_send(telegram_id, position_id):
         return
 
@@ -55,7 +63,10 @@ async def send_health_ratio_notification(
 
         await asyncio.sleep(retry_after)
         await send_health_ratio_notification(
-            telegram_id, health_ratio, position_id=position_id, retry_count=retry_count - 1
+            telegram_id,
+            health_ratio,
+            position_id=position_id,
+            retry_count=retry_count - 1,
         )
     except Exception as e:
         if position_id:

--- a/quantara/web_app/tests/db/test_telegram_user.py
+++ b/quantara/web_app/tests/db/test_telegram_user.py
@@ -163,3 +163,15 @@ def test_set_allow_notification(telegram_user_db):
     with patch.object(telegram_user_db, "save_or_update_user", return_value=True):
         result = telegram_user_db.set_allow_notification("t9", "w9")
         assert result is True
+
+
+def test_get_notification_recipients_returns_only_query_results(telegram_user_db):
+    """Return the distinct opted-in Telegram IDs selected by the query."""
+    session = MagicMock()
+    telegram_user_db.Session.return_value.__enter__.return_value = session
+    session.query.return_value.filter.return_value.distinct.return_value.all.return_value = [
+        ("t1",),
+        ("t2",),
+    ]
+
+    assert telegram_user_db.get_notification_recipients() == ["t1", "t2"]

--- a/quantara/web_app/tests/test_telegram_admin.py
+++ b/quantara/web_app/tests/test_telegram_admin.py
@@ -1,0 +1,158 @@
+"""Tests for Telegram incident-response admin commands."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from web_app.telegram.config import parse_admin_ids
+from web_app.telegram.handlers import admin
+
+
+def _message(user_id=7):
+    return SimpleNamespace(
+        from_user=SimpleNamespace(id=user_id),
+        answer=AsyncMock(),
+    )
+
+
+def _callback(data, user_id=7):
+    return SimpleNamespace(
+        from_user=SimpleNamespace(id=user_id),
+        data=data,
+        answer=AsyncMock(),
+        bot=SimpleNamespace(send_message=AsyncMock()),
+        message=SimpleNamespace(edit_text=AsyncMock()),
+    )
+
+
+def test_parse_admin_ids_ignores_blanks_and_invalid_values():
+    assert parse_admin_ids(" 7,8,invalid,, 9 ") == frozenset({7, 8, 9})
+
+
+async def test_broadcast_requires_an_admin_even_when_called_directly():
+    message = _message(user_id=99)
+
+    with patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})):
+        await admin.broadcast_cmd(message, SimpleNamespace(args="maintenance"))
+
+    message.answer.assert_awaited_once_with("Admin authorization required.")
+
+
+async def test_broadcast_stages_message_with_confirmation():
+    message = _message()
+    redis_client = MagicMock()
+    redis_client.ttl = AsyncMock(return_value=-2)
+    redis_client.setex = AsyncMock()
+
+    with (
+        patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})),
+        patch.object(admin, "get_redis_client", return_value=redis_client),
+        patch.object(admin.secrets, "token_urlsafe", return_value="nonce"),
+    ):
+        await admin.broadcast_cmd(message, SimpleNamespace(args=" maintenance "))
+
+    redis_client.setex.assert_awaited_once_with(
+        admin._pending_key(7, "nonce"),
+        admin.BROADCAST_CONFIRM_TTL_SECONDS,
+        "maintenance",
+    )
+    text, keyboard = (
+        message.answer.await_args.args[0],
+        message.answer.await_args.kwargs["reply_markup"],
+    )
+    assert "maintenance" in text
+    assert keyboard.inline_keyboard[0][0].callback_data.endswith(":nonce")
+
+
+async def test_confirm_broadcast_enforces_rate_limit_and_reports_delivery():
+    callback = _callback("admin:broadcast:confirm:nonce")
+    callback.bot.send_message.side_effect = [None, RuntimeError("blocked")]
+    redis_client = MagicMock()
+    redis_client.get = AsyncMock(return_value="maintenance")
+    redis_client.set = AsyncMock(return_value=True)
+    redis_client.delete = AsyncMock()
+
+    with (
+        patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})),
+        patch.object(admin, "get_redis_client", return_value=redis_client),
+        patch.object(
+            admin.telegram_db,
+            "get_notification_recipients",
+            return_value=["11", "22"],
+        ),
+    ):
+        await admin.confirm_broadcast(callback)
+
+    redis_client.set.assert_awaited_once_with(
+        admin._rate_key(7),
+        "1",
+        ex=admin.BROADCAST_RATE_LIMIT_SECONDS,
+        nx=True,
+    )
+    assert callback.bot.send_message.await_count == 2
+    callback.message.edit_text.assert_awaited_once_with(
+        "Broadcast complete: 1 sent, 1 failed."
+    )
+
+
+async def test_confirm_broadcast_rejects_second_send_within_hour():
+    callback = _callback("admin:broadcast:confirm:nonce")
+    redis_client = MagicMock()
+    redis_client.get = AsyncMock(return_value="maintenance")
+    redis_client.set = AsyncMock(return_value=None)
+
+    with (
+        patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})),
+        patch.object(admin, "get_redis_client", return_value=redis_client),
+    ):
+        await admin.confirm_broadcast(callback)
+
+    callback.answer.assert_awaited_once_with(
+        "Broadcast rate limit active.", show_alert=True
+    )
+    callback.bot.send_message.assert_not_awaited()
+
+
+async def test_pause_persists_redis_record_with_requested_ttl():
+    message = _message()
+    redis_client = MagicMock()
+    redis_client.set = AsyncMock()
+
+    with (
+        patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})),
+        patch.object(admin, "get_redis_client", return_value=redis_client),
+    ):
+        await admin.pause_cmd(message, SimpleNamespace(args="15"))
+
+    redis_client.set.assert_awaited_once_with(
+        admin.NOTIFICATION_PAUSE_KEY,
+        "7",
+        ex=15 * 60,
+    )
+
+
+async def test_health_reports_redis_latency_and_uptime():
+    message = _message()
+    redis_client = MagicMock()
+    redis_client.ping = AsyncMock(return_value=True)
+
+    with (
+        patch.object(admin, "TELEGRAM_ADMIN_USER_IDS", frozenset({7})),
+        patch.object(admin, "get_redis_client", return_value=redis_client),
+    ):
+        await admin.health_cmd(message)
+
+    response = message.answer.await_args.args[0]
+    assert "Bot uptime:" in response
+    assert "Redis: up" in response
+
+
+async def test_paused_notifications_are_suppressed():
+    from web_app.telegram import notifications
+
+    notifications.bot = SimpleNamespace(send_message=AsyncMock())
+    with patch.object(
+        notifications, "notifications_are_paused", AsyncMock(return_value=True)
+    ):
+        await notifications.send_health_ratio_notification("11", 1.5)
+
+    notifications.bot.send_message.assert_not_awaited()


### PR DESCRIPTION
## Summary

- add admin-only `/broadcast`, `/pause`, and `/health` Telegram commands
- stage broadcasts behind an expiring inline confirmation and enforce an atomic one-hour Redis rate limit per caller
- send broadcasts only to Telegram users who opted in to notifications
- persist notification pauses in Redis with the requested TTL and enforce the pause in the alert delivery path
- report bot uptime and Redis latency with a 1.5-second Redis timeout
- document `TELEGRAM_ADMIN_USER_IDS` and register the new router

## Why

Operators need Telegram-native incident controls when the dashboard is unavailable or too slow for time-sensitive events. Redis-backed state keeps rate limits and pauses consistent across bot processes and restarts.

## Validation

- 34 targeted Telegram/admin/database tests passed
- Black formatting check passed for all changed Python files
- Python `compileall` passed for changed modules
- `git diff --check`

Closes #283
