### PR TITLE
feat(api): add standardised error envelope and enrich OpenAPI spec

### DIFF
--- a/quantara/web_app/api/errors.py
+++ b/quantara/web_app/api/errors.py
@@ -1,0 +1,202 @@
+"""
+Standardised error envelope and custom OpenAPI schema generator.
+
+Every error response from the Quantara API uses the same JSON shape::
+
+    {
+        "detail": "Human-readable description of what went wrong.",
+        "code":   "machine_readable_error_code",
+        "request_id": "uuid-attached-to-this-request"
+    }
+
+Usage
+-----
+Raise :class:`APIError` instead of FastAPI's bare ``HTTPException``:
+
+    from web_app.api.errors import APIError
+    raise APIError(status_code=404, code="position_not_found",
+                   detail="No position with that ID exists.")
+
+The ``request_id`` is injected automatically from the structlog context set by
+the ``request_id_middleware`` in ``main.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Error envelope schema
+# ---------------------------------------------------------------------------
+
+
+class ErrorEnvelope(BaseModel):
+    """Standardised JSON error response body."""
+
+    detail: str = Field(
+        ...,
+        description="Human-readable description of what went wrong.",
+        example="No position with that ID exists.",
+    )
+    code: str = Field(
+        ...,
+        description="Machine-readable error code for client-side handling.",
+        example="position_not_found",
+    )
+    request_id: str = Field(
+        ...,
+        description="Unique identifier for this request (echo of X-Request-Id header).",
+        example="3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "detail": "No position with that ID exists.",
+                "code": "position_not_found",
+                "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            }
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# APIError — typed HTTPException with a machine-readable code
+# ---------------------------------------------------------------------------
+
+
+class APIError(HTTPException):
+    """
+    HTTPException subclass that carries a machine-readable ``code``.
+
+    Parameters
+    ----------
+    status_code:
+        HTTP status code (e.g. 400, 404, 422).
+    code:
+        Snake-case error identifier (e.g. ``"position_not_found"``).
+    detail:
+        Human-readable explanation shown to the caller.
+    headers:
+        Optional extra response headers.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        detail: str,
+        headers: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.code = code
+
+
+# ---------------------------------------------------------------------------
+# Exception handler
+# ---------------------------------------------------------------------------
+
+
+async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+    """
+    Convert an :class:`APIError` into a standard :class:`ErrorEnvelope` response.
+
+    Registered via ``app.add_exception_handler(APIError, api_error_handler)``
+    in ``main.py``.
+    """
+    request_id: str = (
+        structlog.contextvars.get_contextvars().get("request_id")
+        or request.headers.get("X-Request-Id", "-")
+    )
+    body = ErrorEnvelope(
+        detail=exc.detail,
+        code=exc.code,
+        request_id=request_id,
+    )
+    headers = dict(exc.headers or {})
+    headers["X-Request-Id"] = request_id
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=body.model_dump(),
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared 4xx / 5xx response specs injected into every endpoint by the
+# custom OpenAPI generator.
+# ---------------------------------------------------------------------------
+
+COMMON_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    400: {
+        "description": "Bad Request — invalid input or missing required field.",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorEnvelope"},
+                "example": {
+                    "detail": "multiplier must be a valid number",
+                    "code": "validation_error",
+                    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                },
+            }
+        },
+    },
+    401: {
+        "description": "Unauthorized — authentication is required.",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorEnvelope"},
+                "example": {
+                    "detail": "Wallet signature verification failed.",
+                    "code": "unauthorized",
+                    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                },
+            }
+        },
+    },
+    404: {
+        "description": "Not Found — the requested resource does not exist.",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorEnvelope"},
+                "example": {
+                    "detail": "No position with that ID exists.",
+                    "code": "not_found",
+                    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                },
+            }
+        },
+    },
+    422: {
+        "description": "Unprocessable Entity — request body failed schema validation.",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorEnvelope"},
+                "example": {
+                    "detail": "field required: wallet_id",
+                    "code": "unprocessable_entity",
+                    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                },
+            }
+        },
+    },
+    500: {
+        "description": "Internal Server Error.",
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorEnvelope"},
+                "example": {
+                    "detail": "Internal server error",
+                    "code": "internal_server_error",
+                    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                },
+            }
+        },
+    },
+}

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -23,6 +23,8 @@ from sqlalchemy.orm import Session
 import redis.asyncio as redis
 
 from web_app.api.rate_limiter import limiter
+from web_app.api.errors import APIError, api_error_handler
+from web_app.api.openapi import build_custom_openapi
 from web_app.api.dashboard import router as dashboard_router
 from web_app.api.position import router as position_router
 from web_app.api.telegram import router as telegram_router
@@ -121,6 +123,10 @@ app = FastAPI(
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_exception_handler(APIError, api_error_handler)
+
+# Enrich the OpenAPI schema with the standardised error envelope and examples.
+app.openapi = build_custom_openapi(app)
 
 
 @app.exception_handler(Exception)

--- a/quantara/web_app/api/openapi.py
+++ b/quantara/web_app/api/openapi.py
@@ -1,0 +1,108 @@
+"""
+Custom OpenAPI schema generator for the Quantara API.
+
+Replaces FastAPI's default ``app.openapi()`` with a function that:
+
+* Injects the :class:`~web_app.api.errors.ErrorEnvelope` component schema.
+* Adds standardised 400 / 401 / 404 / 422 / 500 response examples to every
+  endpoint that does not already declare them.
+* Ensures ``/docs`` (Swagger UI) and ``/redoc`` are always available.
+
+Usage (in ``main.py``)::
+
+    from web_app.api.openapi import build_custom_openapi
+    app.openapi = build_custom_openapi(app)
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from web_app.api.errors import COMMON_ERROR_RESPONSES, ErrorEnvelope
+
+
+def build_custom_openapi(app: FastAPI) -> Callable[[], dict]:
+    """
+    Return a zero-argument callable that produces (and caches) the enriched
+    OpenAPI schema for *app*.
+
+    The returned callable is meant to be assigned directly to
+    ``app.openapi``::
+
+        app.openapi = build_custom_openapi(app)
+    """
+
+    def custom_openapi() -> dict:
+        # Use cached schema if already generated (FastAPI's own caching pattern).
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            license_info=app.license_info,
+            routes=app.routes,
+        )
+
+        # ----------------------------------------------------------------
+        # 1. Inject the ErrorEnvelope component schema so that $ref works.
+        # ----------------------------------------------------------------
+        components = openapi_schema.setdefault("components", {})
+        schemas = components.setdefault("schemas", {})
+
+        # Generate the JSON schema from the Pydantic model.
+        envelope_schema = ErrorEnvelope.model_json_schema()
+        # Remove any $defs nesting – we want a flat component entry.
+        envelope_schema.pop("$defs", None)
+        schemas["ErrorEnvelope"] = envelope_schema
+
+        # ----------------------------------------------------------------
+        # 2. Enrich every path/operation with common error responses.
+        # ----------------------------------------------------------------
+        for _path, path_item in openapi_schema.get("paths", {}).items():
+            for _method, operation in path_item.items():
+                if not isinstance(operation, dict):
+                    continue  # skip non-operation keys like "parameters"
+
+                responses = operation.setdefault("responses", {})
+                for status_code, response_spec in COMMON_ERROR_RESPONSES.items():
+                    str_code = str(status_code)
+                    # Only add if the endpoint hasn't declared its own.
+                    if str_code not in responses:
+                        responses[str_code] = response_spec
+
+        # ----------------------------------------------------------------
+        # 3. Add top-level API info tags description.
+        # ----------------------------------------------------------------
+        openapi_schema.setdefault("tags", [])
+        _ensure_tag(openapi_schema, "Health", "Service health and readiness probes.")
+        _ensure_tag(openapi_schema, "Positions", "Leveraged position lifecycle management.")
+        _ensure_tag(openapi_schema, "Dashboard", "Aggregated portfolio metrics.")
+        _ensure_tag(openapi_schema, "User", "User profile and contract management.")
+        _ensure_tag(openapi_schema, "Vault", "Collateral vault deposits and balances.")
+        _ensure_tag(openapi_schema, "Leaderboard", "Protocol-wide leaderboard statistics.")
+        _ensure_tag(openapi_schema, "Referral", "Referral link generation and tracking.")
+        _ensure_tag(openapi_schema, "Telegram", "Telegram mini-app integration.")
+        _ensure_tag(openapi_schema, "Auth", "Wallet-based authentication (Stellar).")
+        _ensure_tag(openapi_schema, "Metrics", "Prometheus metrics endpoint.")
+
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    return custom_openapi
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tag(schema: dict, name: str, description: str) -> None:
+    """Add a tag entry to the schema if not already present."""
+    existing_names = {t.get("name") for t in schema.get("tags", [])}
+    if name not in existing_names:
+        schema["tags"].append({"name": name, "description": description})

--- a/quantara/web_app/tests/test_openapi_error_envelope.py
+++ b/quantara/web_app/tests/test_openapi_error_envelope.py
@@ -1,0 +1,178 @@
+"""
+Tests for the standardised error envelope (issue #217).
+
+Verifies:
+- APIError produces the correct ErrorEnvelope JSON shape.
+- /docs and /redoc endpoints are accessible.
+- OpenAPI schema includes the ErrorEnvelope component.
+- Common error responses (400, 401, 404, 422, 500) appear in the schema.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from web_app.api.errors import APIError, ErrorEnvelope
+from web_app.api.main import app
+from web_app.db.database import get_database
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_database] = lambda: MagicMock()
+    with patch("web_app.api.main.redis.from_url") as mock_redis:
+        mock_redis.return_value.ping = AsyncMock(return_value=True)
+        mock_redis.return_value.close = AsyncMock(return_value=None)
+        with TestClient(app, raise_server_exceptions=False) as c:
+            yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# APIError handler tests
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_returns_envelope_shape(client):
+    """APIError is rendered as an ErrorEnvelope JSON body."""
+
+    @app.get("/test-api-error-404")
+    async def raise_404():
+        raise APIError(
+            status_code=404,
+            code="position_not_found",
+            detail="No position with that ID exists.",
+        )
+
+    response = client.get("/test-api-error-404")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["detail"] == "No position with that ID exists."
+    assert body["code"] == "position_not_found"
+    assert "request_id" in body
+    assert len(body["request_id"]) > 0
+
+
+def test_api_error_400(client):
+    """APIError with status 400 produces the correct envelope."""
+
+    @app.get("/test-api-error-400")
+    async def raise_400():
+        raise APIError(
+            status_code=400,
+            code="validation_error",
+            detail="multiplier must be a valid number",
+        )
+
+    response = client.get("/test-api-error-400")
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "validation_error"
+    assert body["detail"] == "multiplier must be a valid number"
+    assert "request_id" in body
+
+
+def test_api_error_response_includes_request_id_header(client):
+    """The X-Request-Id response header is set for APIError responses."""
+
+    @app.get("/test-api-error-request-id")
+    async def raise_error():
+        raise APIError(status_code=401, code="unauthorized", detail="Auth required.")
+
+    response = client.get("/test-api-error-request-id")
+    assert response.status_code == 401
+    assert "x-request-id" in response.headers
+
+
+# ---------------------------------------------------------------------------
+# /docs and /redoc reachability
+# ---------------------------------------------------------------------------
+
+
+def test_swagger_ui_docs_endpoint(client):
+    """/docs returns 200 HTML (Swagger UI)."""
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_redoc_endpoint(client):
+    """/redoc returns 200 HTML (ReDoc UI)."""
+    response = client.get("/redoc")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI schema content
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_schema_contains_error_envelope_component(client):
+    """The OpenAPI schema exposes the ErrorEnvelope component."""
+    # Reset cached schema so our custom builder runs fresh.
+    app.openapi_schema = None
+    schema = app.openapi()
+    components = schema.get("components", {})
+    schemas = components.get("schemas", {})
+    assert "ErrorEnvelope" in schemas, (
+        "ErrorEnvelope component not found in OpenAPI schema components"
+    )
+
+
+def test_openapi_schema_error_envelope_has_required_fields(client):
+    """ErrorEnvelope component schema includes detail, code, request_id."""
+    app.openapi_schema = None
+    schema = app.openapi()
+    envelope = schema["components"]["schemas"]["ErrorEnvelope"]
+    props = envelope.get("properties", {})
+    assert "detail" in props
+    assert "code" in props
+    assert "request_id" in props
+
+
+def test_openapi_schema_paths_include_common_error_codes(client):
+    """All paths include at least 422 and 500 in their responses."""
+    app.openapi_schema = None
+    schema = app.openapi()
+    paths = schema.get("paths", {})
+    assert len(paths) > 0, "No paths found in schema"
+    for path, path_item in paths.items():
+        for method, operation in path_item.items():
+            if not isinstance(operation, dict):
+                continue
+            responses = operation.get("responses", {})
+            # Every operation must have 500 injected at minimum.
+            assert "500" in responses, (
+                f"Path {method.upper()} {path} missing 500 response"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ErrorEnvelope model validation
+# ---------------------------------------------------------------------------
+
+
+def test_error_envelope_model_requires_all_fields():
+    """ErrorEnvelope validates that all three fields are required."""
+    import pytest
+
+    with pytest.raises(Exception):
+        ErrorEnvelope(detail="only detail")  # missing code and request_id
+
+
+def test_error_envelope_model_serializes_correctly():
+    """ErrorEnvelope serialises to the expected dict structure."""
+    envelope = ErrorEnvelope(
+        detail="test error",
+        code="test_code",
+        request_id="abc-123",
+    )
+    data = envelope.model_dump()
+    assert data == {
+        "detail": "test error",
+        "code": "test_code",
+        "request_id": "abc-123",
+    }


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Introduced `APIError` (`HTTPException` subclass) carrying a machine-readable `code` field
- Added `ErrorEnvelope` Pydantic model: `{"detail": "...", "code": "...", "request_id": "..."}`
- Registered `api_error_handler` that renders `APIError` as `ErrorEnvelope` JSON
- Added `build_custom_openapi` generator that injects `ErrorEnvelope` into OpenAPI components and appends standard 400/401/404/422/500 responses to every endpoint
- `/docs` (Swagger UI) and `/redoc` (ReDoc) remain accessible and show all endpoints with examples
- Added `test_openapi_error_envelope.py` with 10 passing tests
- Verified linting and build
- Ensured no unrelated changes were introduced

Closes #217