### PR TITLE
fix(security): use hmac.compare_digest for Telegram auth

### DIFF
--- a/quantara/web_app/telegram/utils.py
+++ b/quantara/web_app/telegram/utils.py
@@ -53,7 +53,13 @@ def check_telegram_authorization(
         secret_key, data_check_string.encode(), hashlib.sha256
     ).hexdigest()
 
-    if hash_value != check_hash:
+    # Constant-time compare so a remote timing oracle cannot recover the
+    # expected hash byte-by-byte (see issue #203). Unequal-length inputs
+    # make compare_digest raise; treat that as a failed verification.
+    try:
+        if not hmac.compare_digest(hash_value, check_hash):
+            return False
+    except (TypeError, ValueError):
         return False
 
     if expiration_seconds and (int(time.time()) - int(auth_data.get("auth_date", 0))) > expiration_seconds:

--- a/quantara/web_app/tests/test_telegram.py
+++ b/quantara/web_app/tests/test_telegram.py
@@ -146,6 +146,22 @@ class TestCheckTelegramAuthorization:
         )
         assert ok is False
 
+    def test_uses_constant_time_compare(self):
+        """Hash comparison must use hmac.compare_digest (timing-safe)."""
+        import hmac as hmac_mod
+        from web_app.telegram.utils import check_telegram_authorization
+
+        data = self._build_auth(self.BOT_TOKEN)
+        with patch.object(
+            hmac_mod, "compare_digest", wraps=hmac_mod.compare_digest
+        ) as mock_cmp:
+            assert check_telegram_authorization(self.BOT_TOKEN, data) is True
+            assert mock_cmp.called
+            # Both sides must be str hex digests of equal length.
+            left, right = mock_cmp.call_args[0]
+            assert isinstance(left, str) and isinstance(right, str)
+            assert len(left) == len(right) == 64
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 2. notifications.send_health_ratio_notification


### PR DESCRIPTION
## Summary
Closes #203.

`check_telegram_authorization` compared Telegram initData hashes with `!=`, which short-circuits on the first differing byte and is theoretically timing-observable. This PR switches to `hmac.compare_digest` (constant-time) and fails closed on unequal-length/type inputs.

## Changes
- `quantara/web_app/telegram/utils.py`: use `hmac.compare_digest`
- `quantara/web_app/tests/test_telegram.py`: assert `compare_digest` is used

## Test plan
- [x] Local unit check: valid hash → True; wrong hash → False; short hash → False
- [x] New test pins `hmac.compare_digest` call path
- [ ] CI full suite