### PR TITLE
fix(security): require JSON Content-Type on mutating routes

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -36,7 +36,11 @@ from web_app.api.pausable import protocol_pause_middleware
 from web_app.api.pausable import router as pausable_router
 from web_app.api.walletconnect import router as walletconnect_router
 from web_app.config_validator import assert_valid_config
-from web_app.api.middleware import MaxBodySizeMiddleware, SecurityHeadersMiddleware
+from web_app.api.middleware import (
+    MaxBodySizeMiddleware,
+    RequireJsonContentTypeMiddleware,
+    SecurityHeadersMiddleware,
+)
 from web_app.db.database import init_db
 from web_app.db.database import init_db, get_database
 from web_app.utils.logger import configure_logging, get_logger
@@ -165,6 +169,7 @@ app.add_middleware(
 # full middleware stack and can reject requests before they reach routers.
 app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(MaxBodySizeMiddleware, max_body_size=1024*1024)
+app.add_middleware(RequireJsonContentTypeMiddleware)
 app.add_middleware(PrometheusMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 

--- a/quantara/web_app/api/middleware.py
+++ b/quantara/web_app/api/middleware.py
@@ -109,3 +109,99 @@ class MaxBodySizeMiddleware:
             "body": json.dumps({"detail": "Request payload too large"}).encode("utf-8"),
             "more_body": False
         })
+
+
+# Paths that accept mutation bodies and must be JSON-only (issue #205).
+DEFAULT_MUTATING_PATH_PREFIXES = (
+    "/api/add-extra-deposit/",
+    "/api/save-bug-report",
+)
+
+# Methods that carry a body and should be constrained on mutating routes.
+_MUTATING_METHODS = frozenset({b"POST", b"PUT", b"PATCH", b"DELETE"})
+
+
+class RequireJsonContentTypeMiddleware:
+    """Reject non-JSON bodies on mutating API routes.
+
+    FastAPI/Pydantic can accept form-encoded or multipart bodies for models
+    that look like JSON. This middleware fails closed on configured mutating
+    path prefixes unless ``Content-Type`` is ``application/json`` (optionally
+    with a charset parameter). Safe methods (GET/HEAD/OPTIONS) and non-matching
+    paths are never blocked.
+    """
+
+    def __init__(
+        self,
+        app,
+        mutating_path_prefixes: tuple[str, ...] = DEFAULT_MUTATING_PATH_PREFIXES,
+    ):
+        self.app = app
+        self.mutating_path_prefixes = mutating_path_prefixes
+
+    def _is_mutating_path(self, path: str) -> bool:
+        for prefix in self.mutating_path_prefixes:
+            if path == prefix.rstrip("/") or path.startswith(prefix):
+                return True
+        return False
+
+    @staticmethod
+    def _content_type(scope) -> str:
+        for name, value in scope.get("headers", []):
+            if name.lower() == b"content-type":
+                return value.decode("latin-1").split(";", 1)[0].strip().lower()
+        return ""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET").encode("ascii")
+        path = scope.get("path", "")
+        is_mutating = self._is_mutating_path(path)
+
+        # Expose flag for downstream consumers as noted in #205.
+        state = scope.get("state")
+        if state is not None and not isinstance(state, dict):
+            try:
+                state.is_mutating = is_mutating
+            except Exception:
+                pass
+        else:
+            scope.setdefault("state", {})
+            if isinstance(scope["state"], dict):
+                scope["state"]["is_mutating"] = is_mutating
+
+        if method in _MUTATING_METHODS and is_mutating:
+            content_type = self._content_type(scope)
+            if content_type != "application/json":
+                await self._send_415(send)
+                return
+
+        await self.app(scope, receive, send)
+
+    async def _send_415(self, send):
+        body = json.dumps(
+            {
+                "detail": "Unsupported Media Type. Use Content-Type: application/json",
+                "accept": "application/json",
+            }
+        ).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 415,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"accept", b"application/json"),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": body,
+                "more_body": False,
+            }
+        )

--- a/quantara/web_app/tests/test_middleware_content_type.py
+++ b/quantara/web_app/tests/test_middleware_content_type.py
@@ -1,0 +1,107 @@
+"""Tests for RequireJsonContentTypeMiddleware (issue #205).
+
+Mounted on a tiny FastAPI app so these tests do not pull the full
+application stack (Redis, DB, Sentry, etc.).
+"""
+
+import json
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from web_app.api.middleware import (
+    DEFAULT_MUTATING_PATH_PREFIXES,
+    RequireJsonContentTypeMiddleware,
+)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    @app.post("/api/save-bug-report")
+    async def save_bug(request: Request):
+        return {"received": True, "is_mutating": getattr(request.state, "is_mutating", None)}
+
+    @app.post("/api/add-extra-deposit/{position_id}")
+    async def extra_deposit(position_id: str, request: Request):
+        return {
+            "position_id": position_id,
+            "is_mutating": getattr(request.state, "is_mutating", None),
+        }
+
+    @app.post("/api/other")
+    async def other():
+        return {"other": True}
+
+    app.add_middleware(RequireJsonContentTypeMiddleware)
+    return app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_build_app())
+
+
+def test_post_text_plain_rejected_on_bug_report(client):
+    response = client.post(
+        "/api/save-bug-report",
+        content=b"not-json",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 415
+    body = response.json()
+    assert "application/json" in body.get("accept", "")
+    assert response.headers.get("accept") == "application/json"
+
+
+def test_post_json_accepted_on_bug_report(client):
+    response = client.post(
+        "/api/save-bug-report",
+        json={"title": "x", "body": "y"},
+    )
+    assert response.status_code == 200
+    assert response.json()["received"] is True
+
+
+def test_post_json_with_charset_accepted(client):
+    response = client.post(
+        "/api/save-bug-report",
+        content=json.dumps({"title": "x"}).encode(),
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    assert response.status_code == 200
+
+
+def test_post_form_urlencoded_rejected_on_extra_deposit(client):
+    response = client.post(
+        "/api/add-extra-deposit/pos-1",
+        data={"amount": "1"},
+    )
+    assert response.status_code == 415
+
+
+def test_get_health_never_triggers_check(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_unlisted_post_not_constrained(client):
+    # Paths outside the mutating prefix list stay unrestricted.
+    response = client.post(
+        "/api/other",
+        content=b"anything",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"other": True}
+
+
+def test_default_prefixes_cover_issue_targets():
+    assert any(p.startswith("/api/add-extra-deposit") for p in DEFAULT_MUTATING_PATH_PREFIXES)
+    assert "/api/save-bug-report" in DEFAULT_MUTATING_PATH_PREFIXES


### PR DESCRIPTION
## Summary
Closes #205.

Adds `RequireJsonContentTypeMiddleware` so mutating routes reject non-JSON bodies with HTTP 415 and an `Accept: application/json` hint. Default prefixes cover `/api/add-extra-deposit/*` and `/api/save-bug-report`. GET/health and non-listed paths are unchanged.

## Changes
- `quantara/web_app/api/middleware.py`: new middleware + prefix config
- `quantara/web_app/api/main.py`: register middleware
- `quantara/web_app/tests/test_middleware_content_type.py`: 415 vs JSON vs GET coverage

## Test plan
- [x] `pytest tests/test_middleware_content_type.py` → 7 passed
- [x] POST text/plain → 415
- [x] POST application/json → 200
- [x] GET /health → 200
- [ ] CI full suite