### PR TITLE
fix(security): cap Sentry sampling via env defaults

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -36,6 +36,8 @@ will fail to start in production if any required variable is missing.
 | `RATE_LIMIT_WRITE`        | Limit for mutation endpoints — create/close position, auth (default `5/minute`)  |
 | `RATE_LIMIT_USER_DATA`    | Limit for user-specific data endpoints — dashboard, positions (default `30/minute`) |
 | `RATE_LIMIT_READ`         | Limit for read-only endpoints — multipliers, leaderboard (default `100/minute`)  |
+| `SENTRY_TRACES_SAMPLE_RATE` | Fraction of transactions sent to Sentry (default `0.1`). Applied as the base rate for `traces_sampler`. |
+| `SENTRY_PROFILES_SAMPLE_RATE` | Fraction of profiled transactions (default `0.1`). Replaces the old `_experiments` continuous profiling flag. |
 
 ## Rate limiting
 

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -64,17 +64,24 @@ def get_cors_origins() -> list[str]:
     return [origin for origin in origins if origin] or DEFAULT_CORS_ORIGINS
 
 def custom_traces_sampler(sampling_context):
+    """Scale the base SENTRY_TRACES_SAMPLE_RATE by route importance.
+
+    Returns a sample rate in [0, 1]. Critical auth/bug-report paths keep the
+    full configured rate; health is heavily downsampled; mutations are half;
+    everything else is 5% of the configured rate. Never exceeds the env cap.
+    """
+    base = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1"))
     asgi_scope = sampling_context.get("asgi_scope", {})
     path = asgi_scope.get("path", "")
     method = asgi_scope.get("method", "")
 
     if path in ("/api/save-bug-report", "/api/auth/connect"):
-        return 1.0
+        return base
     if path == "/health":
-        return 0.005
+        return min(base, 0.005)
     if method in ("POST", "PUT", "PATCH", "DELETE"):
-        return 0.5
-    return 0.05
+        return min(base, base * 0.5)
+    return min(base, base * 0.05)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -96,12 +103,18 @@ async def lifespan(app: FastAPI):
     # Initialize Sentry SDK if in production
     if os.getenv("ENV_VERSION") == "PROD":
         import sentry_sdk
+
+        traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1"))
+        profiles_sample_rate = float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.1"))
+        logger.info(
+            "sentry_init",
+            traces_sample_rate=traces_sample_rate,
+            profiles_sample_rate=profiles_sample_rate,
+        )
         sentry_sdk.init(
             dsn=os.getenv("SENTRY_DSN"),
             traces_sampler=custom_traces_sampler,
-            _experiments={
-                "continuous_profiling_auto_start": True,
-            },
+            profiles_sample_rate=profiles_sample_rate,
         )
     yield
 


### PR DESCRIPTION
## Summary
Closes #200.

Sentry was initialized with full-rate sampling via `traces_sampler` returning up to 1.0 and an unstable `_experiments` continuous profiling flag. This PR:

- Caps sampling with `SENTRY_TRACES_SAMPLE_RATE` (default `0.1`) and `SENTRY_PROFILES_SAMPLE_RATE` (default `0.1`)
- Removes `_experiments`
- Logs active rates at startup
- Documents both env vars in `docs/environment_variables.md`

Route-relative weighting is preserved (auth/bug-report keep the configured base rate; health is heavily downsampled).

## Test plan
- [x] Code review of `sentry_sdk.init` call
- [x] Docs updated
- [ ] CI full suite