### PR TITLE
feat: gzip larger API responses

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, Response, Depends
 from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -174,6 +175,7 @@ app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(MaxBodySizeMiddleware, max_body_size=1024*1024)
 app.add_middleware(PrometheusMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(GZipMiddleware, minimum_size=1024)
 
 
 @app.middleware("http")

--- a/quantara/web_app/tests/test_gzip_middleware.py
+++ b/quantara/web_app/tests/test_gzip_middleware.py
@@ -1,0 +1,10 @@
+from web_app.api.main import app
+from starlette.middleware.gzip import GZipMiddleware
+
+
+def test_gzip_middleware_registered_for_json_payloads_over_1kb():
+    middleware_classes = [m.cls for m in app.user_middleware]
+    assert GZipMiddleware in middleware_classes
+
+    gzip_entry = next(m for m in app.user_middleware if m.cls is GZipMiddleware)
+    assert gzip_entry.kwargs["minimum_size"] == 1024


### PR DESCRIPTION
## Summary
- register Starlette GZipMiddleware with minimum_size=1024
- add a focused regression test that verifies the middleware and threshold are configured on the FastAPI app

Closes #213

## Validation
- GitHub compare reports this branch is 1 commit ahead / 0 behind upstream main
- static search confirms GZipMiddleware is imported, registered, and covered by the new test
- checked touched files for trailing whitespace
- did not run local pytest commands because this environment is avoiding project dependency installation and toolchain execution