### PR TITLE
Replace production print calls with structured logging

### DIFF
--- a/quantara/web_app/contract_tools/api_request.py
+++ b/quantara/web_app/contract_tools/api_request.py
@@ -4,6 +4,10 @@ This module handles API requests.
 
 import aiohttp
 
+from web_app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 class APIRequest:
     """
@@ -88,4 +92,4 @@ async def main():
     response = await api.fetch(
         "/overview/0x020281104e6cb5884dabcdf3be376cf4ff7b680741a7bb20e5e07c26cd4870af"
     )
-    print(response)
+    logger.info("api_request_example_response", response=response)

--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -309,4 +309,4 @@ if __name__ == "__main__":
         "X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2"
     )
     res = asyncio.run(StellarClient().fetch_portfolio(dummy_address))
-    print(res)
+    logger.info("portfolio_example_response", response=res)

--- a/quantara/web_app/contract_tools/ekubo_research.py
+++ b/quantara/web_app/contract_tools/ekubo_research.py
@@ -38,6 +38,9 @@ from dataclasses import dataclass
 from typing import List, Dict, Optional, Tuple
 from decimal import Decimal
 import httpx
+from web_app.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from pydantic import BaseModel
 
 
@@ -135,7 +138,7 @@ class EkuboFlashLoan:
                 return self._find_best_route(quote_data, amount, min_profit_bps)
 
         except (httpx.RequestError, ValueError) as e:
-            print(f"Error getting quote: {e}")
+            logger.error("ekubo_quote_error", error=str(e))
             return None
 
     def _find_best_route(

--- a/quantara/web_app/contract_tools/mixins/health_ratio.py
+++ b/quantara/web_app/contract_tools/mixins/health_ratio.py
@@ -11,6 +11,9 @@ from decimal import Decimal
 
 from web_app.contract_tools.blockchain_call import StellarClient
 from web_app.contract_tools.constants import TokenParams
+from web_app.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class HealthRatioMixin:
@@ -104,11 +107,10 @@ class HealthRatioMixin:
 
 
 if __name__ == "__main__":
-    print(
-        asyncio.run(
-            HealthRatioMixin.get_health_ratio_and_tvl(
-                "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2",
-                StellarClient()
-            )
+    result = asyncio.run(
+        HealthRatioMixin.get_health_ratio_and_tvl(
+            "GA7QYNF7SOWQ3GLR2ZGMH2Z5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2X2H5Y2",
+            StellarClient()
         )
     )
+    logger.info("health_ratio_example_result", result=result)

--- a/quantara/web_app/db/seed_data.py
+++ b/quantara/web_app/db/seed_data.py
@@ -39,7 +39,7 @@ def create_users(session: SessionLocal) -> list[User]:
     users = []
     for _ in range(10):
         wallet_id = fake.unique.uuid4()
-        print("wallet_id:", wallet_id)
+        logger.info("seed_user_wallet", wallet_id=wallet_id)
         user = User(
             wallet_id=wallet_id,
             contract_address=fake.address(),

--- a/quantara/web_app/tests/test_no_prints_in_production.py
+++ b/quantara/web_app/tests/test_no_prints_in_production.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+PRODUCTION_ROOTS = (
+    Path("quantara/web_app"),
+    Path("quantara/soroban"),
+)
+
+EXCLUDED_PARTS = {"tests", "test_integration", "__pycache__"}
+
+
+def test_production_python_paths_do_not_use_print():
+    offenders: list[str] = []
+
+    for root in PRODUCTION_ROOTS:
+        for path in root.rglob("*.py"):
+            if any(part in EXCLUDED_PARTS for part in path.parts):
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "print(" in text:
+                offenders.append(str(path))
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- replace the remaining production `print()` calls in web_app helpers with the existing structured logger
- keep example/debug output behind event-named logger calls
- add a static regression test that scans production Python paths for `print(`

## Validation
- Static GitHub API scan of `quantara/web_app` and `quantara/soroban` production Python files found no remaining `print(` calls on this branch
- Compare is 0 commits behind upstream main

Closes #225