### PR TITLE
Validate supported position token symbols

### DIFF
--- a/quantara/web_app/alembic/versions/20260724_add_position_token_symbol_check.py
+++ b/quantara/web_app/alembic/versions/20260724_add_position_token_symbol_check.py
@@ -1,0 +1,33 @@
+"""Add check constraint for supported position token symbols
+
+Revision ID: token_symbol_check_230
+Revises: outbox_event_table_rev
+Create Date: 2026-07-24
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "token_symbol_check_230"
+down_revision = "outbox_event_table_rev"
+branch_labels = None
+depends_on = None
+
+CONSTRAINT_NAME = "ck_position_token_symbol_supported"
+SUPPORTED_TOKENS = ("XLM", "USDC", "ETH", "WETH")
+
+
+def upgrade() -> None:
+    """Restrict position.token_symbol to supported assets."""
+    token_list = ", ".join(f"'{token}'" for token in SUPPORTED_TOKENS)
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        "position",
+        f"token_symbol IN ({token_list})",
+    )
+
+
+def downgrade() -> None:
+    """Remove the supported-token check constraint."""
+    op.drop_constraint(CONSTRAINT_NAME, "position", type_="check")

--- a/quantara/web_app/api/serializers/position.py
+++ b/quantara/web_app/api/serializers/position.py
@@ -29,6 +29,7 @@ class PositionFormData(BaseModel):
             allowed = ", ".join(SUPPORTED_POSITION_TOKENS)
             raise ValueError(f"Token symbol must be one of: {allowed}")
         return token
+
     @field_validator("multiplier", mode="before")
     def validate_multiplier(cls, value: str) -> float:
         """
@@ -114,6 +115,7 @@ class AddPositionDepositData(BaseModel):
             allowed = ", ".join(SUPPORTED_POSITION_TOKENS)
             raise ValueError(f"Token symbol must be one of: {allowed}")
         return token
+
 
 class UserExtraDeposit(BaseModel):
     """

--- a/quantara/web_app/api/serializers/position.py
+++ b/quantara/web_app/api/serializers/position.py
@@ -8,6 +8,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, field_validator
 
+from web_app.db.models import SUPPORTED_POSITION_TOKENS
+
 
 class PositionFormData(BaseModel):
     """
@@ -19,6 +21,14 @@ class PositionFormData(BaseModel):
     amount: str
     multiplier: float
 
+    @field_validator("token_symbol")
+    def validate_token_symbol(cls, value: str) -> str:
+        """Ensure writes use a supported position token."""
+        token = value.upper()
+        if token not in SUPPORTED_POSITION_TOKENS:
+            allowed = ", ".join(SUPPORTED_POSITION_TOKENS)
+            raise ValueError(f"Token symbol must be one of: {allowed}")
+        return token
     @field_validator("multiplier", mode="before")
     def validate_multiplier(cls, value: str) -> float:
         """
@@ -96,6 +106,14 @@ class AddPositionDepositData(BaseModel):
     token_symbol: str
     transaction_hash: Optional[str] = None
 
+    @field_validator("token_symbol")
+    def validate_deposit_token_symbol(cls, value: str) -> str:
+        """Ensure extra deposits use a supported token symbol."""
+        token = value.upper()
+        if token not in SUPPORTED_POSITION_TOKENS:
+            allowed = ", ".join(SUPPORTED_POSITION_TOKENS)
+            raise ValueError(f"Token symbol must be one of: {allowed}")
+        return token
 
 class UserExtraDeposit(BaseModel):
     """

--- a/quantara/web_app/db/models.py
+++ b/quantara/web_app/db/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     NUMERIC,
     Boolean,
     Column,
+    CheckConstraint,
     DateTime,
     Enum,
     Float,
@@ -27,6 +28,7 @@ from sqlalchemy.sql import func
 
 from web_app.db.database import Base
 
+SUPPORTED_POSITION_TOKENS = ("XLM", "USDC", "ETH", "WETH")
 
 class Status(PyEnum):
     """
@@ -103,6 +105,12 @@ class Position(Base):
     is_liquidated = Column(Boolean, default=False, index=True)
     datetime_liquidation = Column(DateTime, nullable=True)
 
+    __table_args__ = (
+        CheckConstraint(
+            "token_symbol IN ('XLM', 'USDC', 'ETH', 'WETH')",
+            name="ck_position_token_symbol_supported",
+        ),
+    )
 
 class AirDrop(Base):
     """

--- a/quantara/web_app/db/models.py
+++ b/quantara/web_app/db/models.py
@@ -30,6 +30,7 @@ from web_app.db.database import Base
 
 SUPPORTED_POSITION_TOKENS = ("XLM", "USDC", "ETH", "WETH")
 
+
 class Status(PyEnum):
     """
     Enum for the position status.

--- a/quantara/web_app/tests/test_token_symbol_validation.py
+++ b/quantara/web_app/tests/test_token_symbol_validation.py
@@ -1,0 +1,42 @@
+import pytest
+from pydantic import ValidationError
+
+from web_app.api.serializers.position import AddPositionDepositData, PositionFormData
+from web_app.db.models import Position, SUPPORTED_POSITION_TOKENS
+
+
+def test_position_form_data_normalizes_supported_token_symbol():
+    form = PositionFormData(
+        wallet_id="GABC",
+        token_symbol="usdc",
+        amount="100",
+        multiplier="2",
+    )
+
+    assert form.token_symbol == "USDC"
+
+
+def test_position_form_data_rejects_unsupported_token_symbol():
+    with pytest.raises(ValidationError):
+        PositionFormData(
+            wallet_id="GABC",
+            token_symbol="DOGE",
+            amount="100",
+            multiplier="2",
+        )
+
+
+def test_extra_deposit_data_rejects_unsupported_token_symbol():
+    with pytest.raises(ValidationError):
+        AddPositionDepositData(amount="50", token_symbol="DOGE")
+
+
+def test_position_model_has_supported_token_check_constraint():
+    constraints = {constraint.name: constraint for constraint in Position.__table__.constraints}
+
+    constraint = constraints["ck_position_token_symbol_supported"]
+    sql = str(constraint.sqltext)
+
+    for token in SUPPORTED_POSITION_TOKENS:
+        assert token in sql
+    assert "DOGE" not in sql


### PR DESCRIPTION
## Summary
- add a SQLAlchemy `CheckConstraint` for supported `Position.token_symbol` values
- add an Alembic migration for the Postgres check constraint
- validate position and extra-deposit token symbols at the Pydantic boundary, normalizing supported lowercase input to uppercase
- add tests for DOGE rejection and model constraint coverage

## Validation
- Static API validation confirmed the model constraint, migration head, Pydantic validators, and DOGE rejection tests are present
- Compare is 0 commits behind upstream main

Closes #230