### PR TITLE
Cache Horizon account lookups briefly

### DIFF
--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -109,32 +109,37 @@ class StellarClient:
 
     async def _get_account_data(self, holder_address: str) -> dict | None:
         """
-        Fetch full account data from Horizon.
+        Fetch full account data from Horizon, cached briefly per account.
         """
         if not holder_address:
             return None
-        url = f"{self.horizon_url.rstrip('/')}/accounts/{holder_address}"
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
-                    if response.status == 404:
-                        logger.info(
-                            "Account %s not found on Stellar network",
-                            holder_address,
-                        )
-                        return None
-                    if response.status != 200:
-                        logger.warning(
-                            "Horizon returned %d for %s", response.status, url
-                        )
-                        return None
-                    return await response.json()
-        except aiohttp.ClientError as exc:
-            logger.error("Network error fetching account %s: %s", holder_address, exc)
-            return None
-        except (ValueError, KeyError, TypeError) as exc:
-            logger.error("Data error fetching account %s: %s", holder_address, exc)
-            return None
+
+        async def fetch_account() -> dict | None:
+            url = f"{self.horizon_url.rstrip('/')}/accounts/{holder_address}"
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(url) as response:
+                        if response.status == 404:
+                            logger.info(
+                                "Account %s not found on Stellar network",
+                                holder_address,
+                            )
+                            return None
+                        if response.status != 200:
+                            logger.warning(
+                                "Horizon returned %d for %s", response.status, url
+                            )
+                            return None
+                        return await response.json()
+            except aiohttp.ClientError as exc:
+                logger.error("Network error fetching account %s: %s", holder_address, exc)
+                return None
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.error("Data error fetching account %s: %s", holder_address, exc)
+                return None
+
+        cache_key = f"horizon:account:{self.horizon_url.rstrip('/')}:{holder_address}"
+        return await get_cached_or_fetch(cache_key, ttl=5, fetch_fn=fetch_account)
 
     async def get_token_balances(
         self, holder_address: str

--- a/quantara/web_app/tests/test_horizon_account_cache_static.py
+++ b/quantara/web_app/tests/test_horizon_account_cache_static.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_get_account_data_uses_horizon_account_cache():
+    source = Path("quantara/web_app/contract_tools/blockchain_call.py").read_text(encoding="utf-8")
+
+    assert "cache_key = f\"horizon:account:" in source
+    assert "get_cached_or_fetch(cache_key, ttl=5, fetch_fn=fetch_account)" in source
+    assert "async def fetch_account()" in source


### PR DESCRIPTION
## Summary
- wrap `_get_account_data` in the existing `get_cached_or_fetch` helper with a 5 second TTL
- key the cache by Horizon base URL and account address
- keep the Horizon fetch/error handling behavior inside a nested fetch function
- add a static regression test for the cache wiring

## Validation
- Static API validation confirmed `_get_account_data` has a single implementation, uses `ttl=5`, includes the Horizon/account cache key, and preserves the following `get_token_balances` method signature
- Compare is 0 commits behind upstream main

Closes #240