### PR TITLE
Use HTTP status constants in API routers

### DIFF
--- a/quantara/web_app/api/errors.py
+++ b/quantara/web_app/api/errors.py
@@ -14,7 +14,7 @@ Usage
 Raise :class:`APIError` instead of FastAPI's bare ``HTTPException``:
 
     from web_app.api.errors import APIError
-    raise APIError(status_code=404, code="position_not_found",
+    raise APIError(status_code=status.HTTP_404_NOT_FOUND, code="position_not_found",
                    detail="No position with that ID exists.")
 
 The ``request_id`` is injected automatically from the structlog context set by
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 import structlog
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -5,7 +5,7 @@ This module handles position-related API endpoints for the Stellar-based Quantar
 from decimal import Decimal, InvalidOperation
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Depends, Request
+from fastapi import APIRouter, HTTPException, Query, Depends, Request, status
 
 from web_app.api.serializers.position import (
     AddPositionDepositData,
@@ -132,16 +132,16 @@ async def get_repay_data(
     :return: Dict containing the repay transaction data
     """
     if not wallet_id:
-        raise HTTPException(status_code=404, detail="Wallet not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wallet not found")
 
     contract_address, position_id, token_symbol = position_db_connector.get_repay_data(
         wallet_id
     )
     is_opened_position = await PositionMixin.is_opened_position(contract_address, client)
     if not is_opened_position:
-        raise HTTPException(status_code=400, detail="Position was closed")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Position was closed")
     if not position_id:
-        raise HTTPException(status_code=404, detail="Position not found or closed")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found or closed")
 
     repay_data = await DepositMixin.get_repay_data(token_symbol, client)
     repay_data["contract_address"] = contract_address
@@ -166,9 +166,9 @@ async def close_position(request: Request, position_id: UUID, transaction_hash: 
     :return: Position status string
     """
     if position_id is None or str(position_id) == "undefined":
-        raise HTTPException(status_code=404, detail="Position not Found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not Found")
     if not transaction_hash:
-        raise HTTPException(status_code=400, detail="Transaction hash is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transaction hash is required")
 
     position_status = position_db_connector.close_position(str(position_id))
     position_db_connector.save_transaction(
@@ -194,9 +194,9 @@ async def open_position(request: Request, position_id: str, transaction_hash: st
     :return: Position status string
     """
     if not position_id:
-        raise HTTPException(status_code=404, detail="Position not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found")
     if not transaction_hash:
-        raise HTTPException(status_code=400, detail="Transaction hash is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transaction hash is required")
 
     from uuid import UUID
     import json
@@ -205,11 +205,11 @@ async def open_position(request: Request, position_id: str, transaction_hash: st
     try:
         pos_uuid = UUID(position_id)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid position ID format")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid position ID format")
 
     position = position_db_connector.get_object(Position, pos_uuid)
     if not position:
-        raise HTTPException(status_code=404, detail="Position not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found")
 
     payload = json.dumps({
         "position_id": str(pos_uuid),
@@ -255,9 +255,9 @@ async def get_withdraw_data(
         wallet_id
     )
     if not await PositionMixin.is_opened_position(contract_address, client):
-        raise HTTPException(status_code=400, detail="Position was closed")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Position was closed")
     if not position_id:
-        raise HTTPException(status_code=404, detail="Position not found or closed")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found or closed")
 
     repay_data = await DepositMixin.get_repay_data(token_symbol, client)
     extra_tokens = position_db_connector.get_extra_deposits_data(position_id).keys()
@@ -292,13 +292,13 @@ async def get_add_deposit_data(request: Request, position_id: UUID, amount: str,
     :return: Dict containing deposit data with token address and amount
     """
     if not amount:
-        raise HTTPException(status_code=400, detail="Amount is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Amount is required")
     if not token_symbol:
-        raise HTTPException(status_code=400, detail="Token symbol is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token symbol is required")
 
     position = position_db_connector.get_position_by_id(position_id)
     if not position:
-        raise HTTPException(status_code=404, detail="Position not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found")
 
     try:
         token_address = TokenParams.get_token_address(token_symbol)
@@ -306,7 +306,7 @@ async def get_add_deposit_data(request: Request, position_id: UUID, amount: str,
             Decimal(amount) * 10 ** TokenParams.get_token_decimals(token_address)
         )
     except InvalidOperation:
-        raise HTTPException(status_code=400, detail="Amount is not a number")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Amount is not a number")
 
     return {
         "deposit_data": {"token_address": token_address, "token_amount": token_amount}
@@ -331,15 +331,15 @@ async def add_extra_deposit(
     :return: Dict containing detail
     """
     if not data.amount:
-        raise HTTPException(status_code=400, detail="Amount is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Amount is required")
     if not data.transaction_hash:
-        raise HTTPException(status_code=400, detail="Transaction hash is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transaction hash is required")
 
     position = position_db_connector.get_position_by_id(position_id)
     if not position:
-        raise HTTPException(status_code=404, detail="Position not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Position not found")
     if position.status != Status.OPENED.value:
-        raise HTTPException(status_code=400, detail="Can only add deposits to open positions")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Can only add deposits to open positions")
 
     position_db_connector.add_extra_deposit_to_position(
         position, data.token_symbol, data.amount
@@ -373,7 +373,7 @@ async def get_user_positions(
     :return: UserPositionHistoryResponse with positions and total count
     """
     if not wallet_id:
-        raise HTTPException(status_code=400, detail="Wallet ID is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wallet ID is required")
 
     positions = position_db_connector.get_all_positions_by_wallet_id(
         wallet_id, start=start, limit=limit

--- a/quantara/web_app/api/referal.py
+++ b/quantara/web_app/api/referal.py
@@ -16,7 +16,7 @@ Errors:
 import random
 import string
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 
 from web_app.db.database import get_database
@@ -75,12 +75,12 @@ async def create_referal_link(
     """
     
     if not wallet_id:
-        raise HTTPException(status_code=400, detail="Wallet ID cannot be empty")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wallet ID cannot be empty")
 
     user = UserDBConnector.get_user_by_wallet_id(db, wallet_id)
     if not user:
         raise HTTPException(
-            status_code=404, detail="User with the provided wallet_id does not exist"
+            status_code=status.HTTP_404_NOT_FOUND, detail="User with the provided wallet_id does not exist"
         )
 
     referral_code = generate_random_string()

--- a/quantara/web_app/api/telegram.py
+++ b/quantara/web_app/api/telegram.py
@@ -12,7 +12,7 @@ from aiogram.types import Update
 from aiogram.utils.deep_linking import create_start_link
 from aiogram.utils.web_app import check_webapp_signature
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, status
 
 from web_app.api.serializers.telegram import TelegramUserAuth, TelegramUserCreate
 from web_app.db.crud import DBConnector, TelegramUserDBConnector, UserDBConnector
@@ -51,11 +51,11 @@ async def generate_telegram_link(request: Request, wallet_id: str):
         dict: Contains the generated subscription link
     """
     if not wallet_id:
-        raise HTTPException(status_code=400, detail="Wallet ID is required")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wallet ID is required")
 
     user = user_db.get_user_by_wallet_id(wallet_id)
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     subscription_link = await create_start_link(bot, user.id, encode=True)
     return {"subscription_link": subscription_link}
@@ -154,7 +154,7 @@ async def get_wallet_id(request: Request, telegram_auth: TelegramUserAuth, teleg
         is_valid = check_telegram_authorization(TELEGRAM_TOKEN, telegram_auth.raw)
 
     if not is_valid:
-        raise HTTPException(400, "Telegram auth data is invalid.")
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Telegram auth data is invalid.")
 
     wallet_id = telegram_user_db_connector.get_wallet_id_by_telegram_id(telegram_id)
     return {"wallet_id": wallet_id}

--- a/quantara/web_app/api/user.py
+++ b/quantara/web_app/api/user.py
@@ -6,7 +6,7 @@ import logging
 from decimal import Decimal
 
 import sentry_sdk
-from fastapi import APIRouter, HTTPException, Depends, Request
+from fastapi import APIRouter, HTTPException, Depends, Request, status
 
 from web_app.api.serializers.transaction import UpdateUserContractRequest
 from web_app.api.serializers.user import (
@@ -65,7 +65,7 @@ async def has_user_opened_position(
         return {"has_opened_position": has_position or is_position_opened}
     except ValueError as e:
         raise HTTPException(
-            status_code=404, detail=f"Invalid wallet ID format: {str(e)}"
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Invalid wallet ID format: {str(e)}"
         )
 
 
@@ -88,9 +88,9 @@ async def get_user_contract(request: Request, wallet_id: str) -> str:
     """
     user = user_db.get_user_by_wallet_id(wallet_id)
     if user is None:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     elif not user.is_contract_deployed:
-        raise HTTPException(status_code=404, detail="Contract not deployed")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contract not deployed")
     else:
         return user.contract_address
 
@@ -182,7 +182,7 @@ async def subscribe_to_notification(
     user = user_db.get_user_by_wallet_id(data.wallet_id)
     # Check if the user exists; if not, raise a 404 error
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     telegram_id = data.telegram_id
     # Is not provided, attempt to retrieve it from the database
@@ -197,7 +197,7 @@ async def subscribe_to_notification(
 
     # If no Telegram ID is available, raise
     raise HTTPException(
-        status_code=400, detail="Failed to subscribe user to notifications"
+        status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to subscribe user to notifications"
     )
 
 
@@ -310,7 +310,7 @@ async def save_bug_report(request: Request, report: BugReportRequest) -> BugRepo
     try:
         if report.wallet_id.strip() == "" or report.bug_description.strip() == "":
             raise HTTPException(
-                status_code=422, detail="Wallet ID and bug description cannot be empty"
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Wallet ID and bug description cannot be empty"
             )
 
         sentry_sdk.set_user(

--- a/quantara/web_app/api/vault.py
+++ b/quantara/web_app/api/vault.py
@@ -4,7 +4,7 @@ Module for handling vault deposit operations in the QUANTARA API.
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from web_app.api.wallet_auth import verify_wallet_signature
 from web_app.db.crud import DepositDBConnector, UserDBConnector
@@ -41,7 +41,7 @@ async def deposit_to_vault(
         user_db = UserDBConnector()
         user = user_db.get_user_by_wallet_id(body.wallet_id)
         if not user:
-            raise HTTPException(status_code=404, detail="User not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
         vault = deposit_connector.create_vault(
             user=user, symbol=body.symbol, amount=body.amount
@@ -55,7 +55,7 @@ async def deposit_to_vault(
         )
     except (ValueError, TypeError) as e:
         logger.error("vault_deposit_invalid_input", error=str(e))
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.get("/balance", response_model=VaultBalanceResponse)
@@ -72,7 +72,7 @@ async def get_user_vault_balance(
     balance = deposit_connector.get_vault_balance(wallet_id=wallet_id, symbol=symbol)
     if balance is None:
         raise HTTPException(
-            status_code=404, detail="Vault not found or user does not exist"
+            status_code=status.HTTP_404_NOT_FOUND, detail="Vault not found or user does not exist"
         )
     return VaultBalanceResponse(wallet_id=wallet_id, symbol=symbol, amount=balance)
 
@@ -101,5 +101,5 @@ async def add_vault_balance(
         )
     except (ValueError, TypeError) as e:
         raise HTTPException(
-            status_code=400, detail=f"Failed to update vault balance: {str(e)}"
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to update vault balance: {str(e)}"
         )

--- a/quantara/web_app/api/wallet_auth.py
+++ b/quantara/web_app/api/wallet_auth.py
@@ -3,7 +3,7 @@ import secrets
 import time
 from typing import Dict, Tuple
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query, status
 
 from stellar_sdk import Keypair
 
@@ -72,12 +72,12 @@ async def verify_wallet_signature(
     """FastAPI dependency -- verifies a Stellar wallet signature and returns the wallet_id."""
     if not _consume_nonce(x_nonce, x_wallet_id):
         raise HTTPException(
-            status_code=401,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired nonce. Request a fresh nonce from /api/auth/nonce.",
         )
     if not _verify_stellar_signature(x_wallet_id, x_nonce, x_signature):
         raise HTTPException(
-            status_code=401,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Signature verification failed. Ensure the nonce was signed with the correct key.",
         )
     return x_wallet_id

--- a/quantara/web_app/api/walletconnect.py
+++ b/quantara/web_app/api/walletconnect.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from typing import Literal, Optional
 
 import redis.asyncio as redis
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
 
 # Note: `from __future__ import annotations` is intentionally NOT used here.
@@ -212,7 +212,7 @@ def _signing_key(sub_sid: str) -> str:
 async def _validate_session(sid: str) -> dict:
     raw = await _redis().get(_session_key(sid))
     if raw is None:
-        raise HTTPException(status_code=404, detail="Pairing session not found or expired")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pairing session not found or expired")
     return json.loads(raw)
 
 
@@ -264,7 +264,7 @@ async def poll_session(session_id: str, request: Request):
     if raw is None:
         raw = await _redis().get(_signing_key(session_id))
     if raw is None:
-        raise HTTPException(status_code=404, detail="Session not found or expired")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found or expired")
     data = json.loads(raw)
     return PollResponse(
         session_id=session_id,
@@ -325,7 +325,7 @@ async def submit_signed_envelope(
         # Wallet hit the pairing endpoint instead of the signing one.
         raw = await _redis().get(_session_key(session_id))
         if raw is None:
-            raise HTTPException(status_code=404, detail="Unknown session")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown session")
         data = json.loads(raw)
         if payload.public_key:
             data["public_key"] = payload.public_key

--- a/quantara/web_app/tests/test_http_status_constants_static.py
+++ b/quantara/web_app/tests/test_http_status_constants_static.py
@@ -1,0 +1,19 @@
+import re
+from pathlib import Path
+
+
+API_ROOT = Path("quantara/web_app/api")
+LITERAL_STATUS_RE = re.compile(
+    r"(status_code\s*=\s*(400|401|404|422)\b|HTTPException\(\s*(400|401|404|422)\s*,)"
+)
+
+
+def test_api_http_exceptions_use_status_constants():
+    offenders: list[str] = []
+
+    for path in API_ROOT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if LITERAL_STATUS_RE.search(text):
+            offenders.append(str(path))
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- replace API HTTP status literals for 400/401/404/422 with `fastapi.status` constants
- cover the touched routers with a static regression test that rejects literal status codes in `HTTPException` calls

## Validation
- Static API validation found no remaining `status_code=400/401/404/422` or positional `HTTPException(400/401/404/422, ...)` patterns in `quantara/web_app/api`
- Static API validation confirmed each touched router imports `status`
- Compare is 0 commits behind upstream main

Closes #226