### PR TITLE
Run health alert checks concurrently

### DIFF
--- a/quantara/web_app/contract_tools/mixins/alert.py
+++ b/quantara/web_app/contract_tools/mixins/alert.py
@@ -2,8 +2,11 @@
 This module contains the alert mixin class for health ratio monitoring.
 """
 
+import asyncio
 import logging
 import os
+
+from prometheus_client import Counter, REGISTRY
 
 from web_app.telegram.notifications import send_health_ratio_notification
 from web_app.contract_tools.mixins.health_ratio import HealthRatioMixin
@@ -13,6 +16,26 @@ from web_app.api.dependencies import get_stellar_client
 
 logger = logging.getLogger(__name__)
 ALERT_THRESHOLD = float(os.getenv("HEALTH_RATIO_ALERT_THRESHOLD", "1.1"))
+ALERT_CONCURRENCY_LIMIT = int(os.getenv("HEALTH_RATIO_ALERT_CONCURRENCY", "16"))
+ALERT_TASK_TIMEOUT_SECONDS = float(os.getenv("HEALTH_RATIO_ALERT_TIMEOUT_SECONDS", "10"))
+
+
+def _get_or_create_counter(name: str, documentation: str, labelnames: list[str]):
+    """Return an existing Prometheus counter or create one."""
+    existing = (
+        REGISTRY._names_to_collectors.get(name)
+        or REGISTRY._names_to_collectors.get(f"{name}_total")
+    )
+    if existing is not None:
+        return existing
+    return Counter(name, documentation, labelnames)
+
+
+ALERT_SWEEP_COUNTER = _get_or_create_counter(
+    "health_ratio_alert_sweep_results_total",
+    "Health-ratio alert sweep results by outcome",
+    ["outcome"],
+)
 
 
 class AlertMixin:
@@ -32,25 +55,60 @@ class AlertMixin:
         users_data = UserDBConnector().get_users_for_notifications()
         client = get_stellar_client()
         user_number = len([user for user, _ in users_data])
-        logger.info(f"Found number of users for notifications: {user_number}")
-        for contract_address, telegram_id in users_data:
-            if not contract_address:
-                continue
+        logger.info("Found number of users for notifications: %s", user_number)
+
+        semaphore = asyncio.Semaphore(ALERT_CONCURRENCY_LIMIT)
+        tasks = [
+            cls._check_single_user_health_ratio(
+                contract_address,
+                telegram_id,
+                client,
+                semaphore,
+            )
+            for contract_address, telegram_id in users_data
+            if contract_address
+        ]
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        success_count = sum(result == "success" for result in results)
+        failure_count = len(results) - success_count
+        ALERT_SWEEP_COUNTER.labels(outcome="success").inc(success_count)
+        ALERT_SWEEP_COUNTER.labels(outcome="failure").inc(failure_count)
+        logger.info(
+            "health_ratio_alert_sweep_summary",
+            extra={"success": success_count, "failure": failure_count},
+        )
+
+    @classmethod
+    async def _check_single_user_health_ratio(
+        cls,
+        contract_address: str,
+        telegram_id: int,
+        client,
+        semaphore: asyncio.Semaphore,
+    ) -> str:
+        """Check one user's health ratio without blocking the full sweep."""
+        async with semaphore:
             try:
-                health_ratio_level, _ = \
-                    await HealthRatioMixin.get_health_ratio_and_tvl(contract_address, client)
-            except Exception as e:
-                logger.error(
-                    "Failed to get health ratio for %s: %s", contract_address, e
+                health_ratio_level, _ = await asyncio.wait_for(
+                    HealthRatioMixin.get_health_ratio_and_tvl(contract_address, client),
+                    timeout=ALERT_TASK_TIMEOUT_SECONDS,
                 )
-                continue
+            except Exception as exc:
+                logger.error(
+                    "Failed to get health ratio for %s: %s", contract_address, exc
+                )
+                return "failure"
 
             health_value = float(health_ratio_level)
             if health_value < ALERT_THRESHOLD:
                 logger.info(
-                    f"Health ratio level for user {contract_address} is {health_ratio_level}"
+                    "Health ratio level for user %s is %s",
+                    contract_address,
+                    health_ratio_level,
                 )
                 await cls.send_notification(telegram_id, health_ratio_level)
+            return "success"
 
     @staticmethod
     async def send_notification(telegram_id: int, health_ratio: float):
@@ -63,5 +121,5 @@ class AlertMixin:
         """
         await send_health_ratio_notification(telegram_id, health_ratio)
         logger.info(
-            f"Notification sent to user {telegram_id} with health ratio {health_ratio}"
+            "Notification sent to user %s with health ratio %s", telegram_id, health_ratio
         )

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -8,7 +8,7 @@ def test_alert_sweep_uses_bounded_concurrency_and_timeout():
     source = ALERT_SOURCE.read_text(encoding="utf-8")
 
     assert "asyncio.Semaphore(ALERT_CONCURRENCY_LIMIT)" in source
-    assert "HEALTH_RATIO_ALERT_CONCURRENCY", "16" in source
+    assert 'HEALTH_RATIO_ALERT_CONCURRENCY", "16"' in source
     assert "asyncio.wait_for(" in source
     assert "timeout=ALERT_TASK_TIMEOUT_SECONDS" in source
     assert "asyncio.gather(*tasks, return_exceptions=True)" in source

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+ALERT_SOURCE = Path("quantara/web_app/contract_tools/mixins/alert.py")
+
+
+def test_alert_sweep_uses_bounded_concurrency_and_timeout():
+    source = ALERT_SOURCE.read_text(encoding="utf-8")
+
+    assert "asyncio.Semaphore(ALERT_CONCURRENCY_LIMIT)" in source
+    assert "HEALTH_RATIO_ALERT_CONCURRENCY", "16" in source
+    assert "asyncio.wait_for(" in source
+    assert "timeout=ALERT_TASK_TIMEOUT_SECONDS" in source
+    assert "asyncio.gather(*tasks, return_exceptions=True)" in source
+
+
+def test_alert_sweep_records_success_and_failure_metrics():
+    source = ALERT_SOURCE.read_text(encoding="utf-8")
+
+    assert "health_ratio_alert_sweep_results_total" in source
+    assert "ALERT_SWEEP_COUNTER.labels(outcome=\"success\").inc(success_count)" in source
+    assert "ALERT_SWEEP_COUNTER.labels(outcome=\"failure\").inc(failure_count)" in source
+    assert "health_ratio_alert_sweep_summary" in source


### PR DESCRIPTION
## Summary
- fan out health-ratio alert checks with a bounded concurrency cap (default 16)
- wrap each user check in a per-task timeout so one slow RPC does not stall the sweep
- use `asyncio.gather(..., return_exceptions=True)` so failures do not stop successful alerts
- record Prometheus success/failure counters and log a sweep summary
- add static coverage for the alert sweep concurrency, timeout, gather, and metrics wiring

## Validation
- Static API validation confirmed semaphore, timeout, gather with `return_exceptions=True`, and success/failure counter wiring are present
- Compare is 0 commits behind upstream main

Closes #206