### PR TITLE
Add SETNX cache stampede protection

### DIFF
--- a/quantara/web_app/contract_tools/cache.py
+++ b/quantara/web_app/contract_tools/cache.py
@@ -9,6 +9,8 @@ import redis.asyncio as redis
 logger = logging.getLogger(__name__)
 
 _REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+_REFRESH_CLAIM_SECONDS = 5
+_REFRESH_POLL_SECONDS = 0.1
 _pool: Optional[redis.ConnectionPool] = None
 _pool_lock = asyncio.Lock()
 
@@ -24,23 +26,66 @@ async def get_redis_pool() -> redis.ConnectionPool:
     return _pool
 
 
+async def _read_cached_value(client: redis.Redis, key: str):
+    cached = await client.get(key)
+    if cached is None:
+        return None
+    return json.loads(cached)
+
+
+async def _wait_for_refresh(client: redis.Redis, key: str):
+    deadline = asyncio.get_running_loop().time() + _REFRESH_CLAIM_SECONDS
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(_REFRESH_POLL_SECONDS)
+        cached = await _read_cached_value(client, key)
+        if cached is not None:
+            return cached
+    return None
+
+
 async def get_cached_or_fetch(
     key: str,
     ttl: int,
     fetch_fn: Callable[[], Awaitable],
 ):
-    """Return cached value for key, or execute fetch_fn on miss."""
+    """Return cached value for key, or execute fetch_fn on miss.
+
+    A cache miss first attempts a short Redis SET NX claim so only one caller
+    refreshes an expired key. Concurrent callers wait up to five seconds for the
+    claimer to publish the value before falling back to their own fetch.
+    """
     pool = await get_redis_pool()
     client = redis.Redis(connection_pool=pool)
+    claim_key = f"{key}:refresh-lock"
     try:
         try:
-            cached = await client.get(key)
+            cached = await _read_cached_value(client, key)
             if cached is not None:
-                return json.loads(cached)
+                return cached
         except Exception as exc:
             logger.warning(
                 "Cache read error (%s), falling through to fetch.", exc
             )
+
+        try:
+            claimed = await client.set(
+                claim_key, "1", nx=True, ex=_REFRESH_CLAIM_SECONDS
+            )
+        except Exception as exc:
+            logger.warning(
+                "Cache refresh claim failed for %s: %s", key, exc
+            )
+            claimed = True
+
+        if not claimed:
+            try:
+                refreshed = await _wait_for_refresh(client, key)
+                if refreshed is not None:
+                    return refreshed
+            except Exception as exc:
+                logger.warning(
+                    "Cache refresh wait failed for %s: %s", key, exc
+                )
 
         value = await fetch_fn()
         try:

--- a/quantara/web_app/tests/test_cache_stampede_static.py
+++ b/quantara/web_app/tests/test_cache_stampede_static.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+CACHE_SOURCE = Path("quantara/web_app/contract_tools/cache.py").read_text()
+
+
+def test_cache_miss_uses_setnx_refresh_claim():
+    assert "claim_key = f\"{key}:refresh-lock\"" in CACHE_SOURCE
+    assert "nx=True" in CACHE_SOURCE
+    assert "ex=_REFRESH_CLAIM_SECONDS" in CACHE_SOURCE
+    assert "_REFRESH_CLAIM_SECONDS = 5" in CACHE_SOURCE
+
+
+def test_concurrent_miss_waits_for_claimer_before_fetching():
+    assert "if not claimed:" in CACHE_SOURCE
+    assert "refreshed = await _wait_for_refresh(client, key)" in CACHE_SOURCE
+    assert "if refreshed is not None:" in CACHE_SOURCE
+    assert "return refreshed" in CACHE_SOURCE
+    assert "value = await fetch_fn()" in CACHE_SOURCE
+
+
+def test_wait_loop_polls_cached_value_with_deadline():
+    assert "deadline = asyncio.get_running_loop().time() + _REFRESH_CLAIM_SECONDS" in CACHE_SOURCE
+    assert "await asyncio.sleep(_REFRESH_POLL_SECONDS)" in CACHE_SOURCE
+    assert "cached = await _read_cached_value(client, key)" in CACHE_SOURCE

--- a/quantara/web_app/tests/test_cache_stampede_static.py
+++ b/quantara/web_app/tests/test_cache_stampede_static.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 
-CACHE_SOURCE = Path("quantara/web_app/contract_tools/cache.py").read_text()
+WEB_APP = Path(__file__).resolve().parents[1]
+CACHE_SOURCE = (WEB_APP / "contract_tools/cache.py").read_text()
 
 
 def test_cache_miss_uses_setnx_refresh_claim():


### PR DESCRIPTION
Fixes #236.

This adds TTL-bound cache stampede protection to get_cached_or_fetch:

- cache misses attempt SET <key>:refresh-lock NX EX 5 before refreshing
- the lock holder computes and writes the cached value as before
- concurrent miss callers poll the cache for up to five seconds and return the value published by the lock holder before falling back to their own fetch
- Redis read/claim/write failures still degrade to the existing fetch behavior
- focused static coverage locks the SETNX claim and wait-before-fetch wiring

I did not run local pytest in this workspace because we are intentionally avoiding dependency installation and project toolchain execution.