### PR TITLE
Add updated_at columns and Postgres triggers

### DIFF
--- a/quantara/web_app/alembic/versions/229_updated_at_triggers.py
+++ b/quantara/web_app/alembic/versions/229_updated_at_triggers.py
@@ -1,0 +1,79 @@
+"""add updated_at audit triggers
+
+Revision ID: updated_at_triggers_229
+Revises: outbox_event_table_rev
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "updated_at_triggers_229"
+down_revision = "outbox_event_table_rev"
+branch_labels = None
+depends_on = None
+
+UPDATED_AT_TABLES = (
+    "user",
+    "position",
+    "airdrop",
+    "telegram_user",
+    "vault",
+    "transaction",
+    "extra_deposits",
+    "event_outbox",
+)
+
+
+def _trigger_name(table_name: str) -> str:
+    return f"set_{table_name}_updated_at"
+
+
+def upgrade() -> None:
+    for table_name in ("user", "position", "airdrop"):
+        op.add_column(
+            table_name,
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION set_updated_at()
+        RETURNS trigger AS $$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    for table_name in UPDATED_AT_TABLES:
+        op.execute(
+            f"""
+            DROP TRIGGER IF EXISTS {_trigger_name(table_name)} ON "{table_name}";
+            CREATE TRIGGER {_trigger_name(table_name)}
+            BEFORE UPDATE ON "{table_name}"
+            FOR EACH ROW
+            EXECUTE FUNCTION set_updated_at();
+            """
+        )
+
+
+def downgrade() -> None:
+    for table_name in reversed(UPDATED_AT_TABLES):
+        op.execute(
+            f'DROP TRIGGER IF EXISTS {_trigger_name(table_name)} ON "{table_name}";'
+        )
+
+    op.execute("DROP FUNCTION IF EXISTS set_updated_at();")
+
+    for table_name in ("airdrop", "position", "user"):
+        op.drop_column(table_name, "updated_at")

--- a/quantara/web_app/db/models.py
+++ b/quantara/web_app/db/models.py
@@ -56,6 +56,9 @@ class User(Base):
     is_contract_deployed = Column(Boolean, default=False)
     wallet_id = Column(String, nullable=False, unique=True, index=True)
     contract_address = Column(String)
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
 
 class Referal(Base):
     """
@@ -88,6 +91,9 @@ class Position(Base):
     multiplier = Column(NUMERIC, nullable=False)
 
     created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
     closed_at = Column(DateTime, nullable=True)
 
     status = Column(
@@ -116,6 +122,9 @@ class AirDrop(Base):
         UUID(as_uuid=True), ForeignKey("user.id"), index=True, nullable=False
     )
     created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
     amount = Column(DECIMAL, nullable=True)
     is_claimed = Column(Boolean, default=False, index=True)
     claimed_at = Column(DateTime, nullable=True)

--- a/quantara/web_app/tests/test_updated_at_triggers_static.py
+++ b/quantara/web_app/tests/test_updated_at_triggers_static.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+MODELS = Path("quantara/web_app/db/models.py").read_text()
+MIGRATION = Path("quantara/web_app/alembic/versions/229_updated_at_triggers.py").read_text()
+
+
+def _class_body(class_name: str) -> str:
+    start = MODELS.index(f"class {class_name}(Base):")
+    next_class = MODELS.find("\nclass ", start + 1)
+    return MODELS[start:] if next_class == -1 else MODELS[start:next_class]
+
+
+def test_core_audit_models_have_updated_at_columns():
+    for class_name in ("User", "Position", "AirDrop"):
+        body = _class_body(class_name)
+        assert "updated_at = Column" in body
+        assert "onupdate=func.now()" in body
+
+
+def test_migration_adds_missing_updated_at_columns():
+    for table_name in ("user", "position", "airdrop"):
+        assert f'op.add_column(\n            table_name,' in MIGRATION
+        assert f'for table_name in ("user", "position", "airdrop"):' in MIGRATION
+    assert 'op.drop_column(table_name, "updated_at")' in MIGRATION
+
+
+def test_migration_installs_triggers_for_all_updated_at_tables():
+    assert "CREATE OR REPLACE FUNCTION set_updated_at()" in MIGRATION
+    assert "NEW.updated_at = NOW();" in MIGRATION
+    for table_name in (
+        "user",
+        "position",
+        "airdrop",
+        "telegram_user",
+        "vault",
+        "transaction",
+        "extra_deposits",
+        "event_outbox",
+    ):
+        assert f'"{table_name}"' in MIGRATION
+    assert "CREATE TRIGGER" in MIGRATION
+    assert "EXECUTE FUNCTION set_updated_at();" in MIGRATION

--- a/quantara/web_app/tests/test_updated_at_triggers_static.py
+++ b/quantara/web_app/tests/test_updated_at_triggers_static.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 
-MODELS = Path("quantara/web_app/db/models.py").read_text()
-MIGRATION = Path("quantara/web_app/alembic/versions/229_updated_at_triggers.py").read_text()
+WEB_APP = Path(__file__).resolve().parents[1]
+MODELS = (WEB_APP / "db/models.py").read_text()
+MIGRATION = (WEB_APP / "alembic/versions/229_updated_at_triggers.py").read_text()
 
 
 def _class_body(class_name: str) -> str:

--- a/quantara/web_app/tests/test_updated_at_triggers_static.py
+++ b/quantara/web_app/tests/test_updated_at_triggers_static.py
@@ -19,9 +19,10 @@ def test_core_audit_models_have_updated_at_columns():
 
 
 def test_migration_adds_missing_updated_at_columns():
+    assert 'for table_name in ("user", "position", "airdrop"):' in MIGRATION
     for table_name in ("user", "position", "airdrop"):
         assert f'op.add_column(\n            table_name,' in MIGRATION
-        assert f'for table_name in ("user", "position", "airdrop"):' in MIGRATION
+        assert table_name in MIGRATION
     assert 'op.drop_column(table_name, "updated_at")' in MIGRATION
 
 


### PR DESCRIPTION
Fixes #229.

This makes updated_at consistent for the audit-facing models and moves the timestamp update guarantee into Postgres:

- adds updated_at columns to User, Position, and AirDrop models
- adds an Alembic migration that backfills those columns with 
ow() defaults
- installs a shared set_updated_at() trigger function for every table that exposes updated_at
- covers the model columns and trigger migration wiring with focused static tests

I did not run local pytest/Alembic commands in this workspace because we are intentionally avoiding dependency installation and project toolchain execution.