### PR TITLE
Require configured session secret in production

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -51,6 +51,15 @@ CORS_ALLOW_METHODS = ["GET", "POST"]
 CORS_ALLOW_HEADERS = ["Content-Type", "Authorization", "X-Wallet-Id", "X-Nonce", "X-Signature"]
 
 
+def get_session_secret() -> str:
+    """Return a configured session secret, allowing random fallback only in dev."""
+    secret = os.getenv("SESSION_SECRET_KEY")
+    if secret:
+        return secret
+    if os.getenv("ENV_VERSION") == "PROD":
+        raise RuntimeError("SESSION_SECRET_KEY must be set in production.")
+    return os.urandom(32).hex()
+
 def get_cors_origins() -> list[str]:
     """
     Return the allowed CORS origins from the environment.
@@ -89,11 +98,6 @@ async def lifespan(app: FastAPI):
 
     # Validate required environment variables at startup.
     assert_valid_config()
-
-    # Enforce minimum length for session secret at startup
-    secret = os.getenv("SESSION_SECRET_KEY")
-    if secret and len(secret) < 32:
-        raise ValueError("SESSION_SECRET_KEY must be at least 32 characters long.")
 
     # Initialize Sentry SDK if in production
     if os.getenv("ENV_VERSION") == "PROD":
@@ -156,7 +160,7 @@ async def global_exception_handler(request: Request, exc: Exception):
 
 # Fetch at import time for middleware registration, but do not raise exceptions here.
 # Strict validation and missing value errors are handled by assert_valid_config() and lifespan().
-_session_secret = os.getenv("SESSION_SECRET_KEY", os.urandom(32).hex())
+_session_secret = get_session_secret()
 
 # Add session middleware with a persistent secret key
 app.add_middleware(AccessLogMiddleware)

--- a/quantara/web_app/config_validator.py
+++ b/quantara/web_app/config_validator.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+SESSION_SECRET_MIN_LENGTH = 32
 
 
 @dataclass
@@ -114,6 +115,18 @@ def validate_required_env_vars(
                         ),
                     )
                 )
+
+        session_secret = os.getenv("SESSION_SECRET_KEY")
+        if session_secret and len(session_secret) < SESSION_SECRET_MIN_LENGTH:
+            result.errors.append(
+                ConfigValidationError(
+                    variable="SESSION_SECRET_KEY",
+                    message=(
+                        "SESSION_SECRET_KEY must be at least "
+                        f"{SESSION_SECRET_MIN_LENGTH} characters long."
+                    ),
+                )
+            )
 
         # In production, Sentry DSN is also required for error tracking.
         sentry_dsn = os.getenv("SENTRY_DSN")

--- a/quantara/web_app/tests/test_session_secret_config.py
+++ b/quantara/web_app/tests/test_session_secret_config.py
@@ -1,0 +1,62 @@
+"""Session secret configuration guards."""
+
+from pathlib import Path
+
+from web_app.config_validator import validate_required_env_vars
+
+
+_REQUIRED_PROD_ENV = {
+    "DB_USER": "quantara",
+    "DB_PASSWORD": "secret-password",
+    "DB_HOST": "db",
+    "DB_NAME": "quantara",
+    "SENTRY_DSN": "https://example.invalid/1",
+}
+
+
+def _set_required_prod_env(monkeypatch):
+    monkeypatch.setenv("ENV_VERSION", "PROD")
+    for key, value in _REQUIRED_PROD_ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+def _errors_by_variable(result):
+    return {error.variable: error.message for error in result.errors}
+
+
+def test_production_requires_session_secret(monkeypatch):
+    _set_required_prod_env(monkeypatch)
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+
+    errors = _errors_by_variable(validate_required_env_vars(is_production=True))
+
+    assert "SESSION_SECRET_KEY" in errors
+    assert "not set" in errors["SESSION_SECRET_KEY"]
+
+
+def test_production_rejects_short_session_secret(monkeypatch):
+    _set_required_prod_env(monkeypatch)
+    monkeypatch.setenv("SESSION_SECRET_KEY", "short")
+
+    errors = _errors_by_variable(validate_required_env_vars(is_production=True))
+
+    assert "SESSION_SECRET_KEY" in errors
+    assert "at least 32 characters" in errors["SESSION_SECRET_KEY"]
+
+
+def test_production_accepts_configured_session_secret(monkeypatch):
+    _set_required_prod_env(monkeypatch)
+    monkeypatch.setenv("SESSION_SECRET_KEY", "a" * 64)
+
+    errors = _errors_by_variable(validate_required_env_vars(is_production=True))
+
+    assert "SESSION_SECRET_KEY" not in errors
+
+
+def test_main_does_not_use_random_session_secret_in_production():
+    main_source = Path(__file__).resolve().parents[1] / "api" / "main.py"
+    source = main_source.read_text(encoding="utf-8")
+
+    assert 'os.getenv("SESSION_SECRET_KEY", os.urandom' not in source
+    assert 'if os.getenv("ENV_VERSION") == "PROD"' in source
+    assert 'raise RuntimeError("SESSION_SECRET_KEY must be set in production.")' in source


### PR DESCRIPTION
Closes #201

## Summary
- validate that production `SESSION_SECRET_KEY` is present and at least 32 characters long
- prevent `api/main.py` from falling back to a generated random session secret in production
- add coverage for missing, short, valid, and no-random-production-secret cases

## Validation
- Static API validation: branch diff is 0 behind upstream main and changes only session secret configuration/test files
- Not run locally: project dependency/toolchain execution is intentionally avoided in this workspace