### PR TITLE
Cache user positions per wallet

### DIFF
--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -55,7 +55,7 @@ def _get_wallet_id_for_position(position_id: UUID) -> str | None:
 
 def _get_wallet_id_for_position_object(position: object | None) -> str | None:
     user_id = getattr(position, "user_id", None)
-    if not user_id:
+    if not isinstance(user_id, UUID):
         return None
     user = position_db_connector.get_object(User, user_id)
     return getattr(user, "wallet_id", None) if user else None

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -50,9 +50,14 @@ async def _invalidate_user_positions_cache(wallet_id: str | None) -> None:
 
 def _get_wallet_id_for_position(position_id: UUID) -> str | None:
     position = position_db_connector.get_position_by_id(position_id)
-    if not position:
+    return _get_wallet_id_for_position_object(position)
+
+
+def _get_wallet_id_for_position_object(position: object | None) -> str | None:
+    user_id = getattr(position, "user_id", None)
+    if not user_id:
         return None
-    user = position_db_connector.get_object(User, position.user_id)
+    user = position_db_connector.get_object(User, user_id)
     return user.wallet_id if user else None
 
 @router.get(
@@ -246,8 +251,9 @@ async def open_position(request: Request, position_id: str, transaction_hash: st
 
     try:
         position_db_connector.write_to_db(outbox_event)
-        user = position_db_connector.get_object(User, position.user_id)
-        await _invalidate_user_positions_cache(user.wallet_id if user else None)
+        await _invalidate_user_positions_cache(
+            _get_wallet_id_for_position_object(position)
+        )
     except Exception as e:
         logger.error("failed_to_write_outbox_event", error=str(e))
         raise HTTPException(status_code=500, detail="Failed to queue position opening")
@@ -370,8 +376,9 @@ async def add_extra_deposit(
     transaction_db_connector.create_transaction(
         position_id, data.transaction_hash, status=TransactionStatus.EXTRA_DEPOSIT.value
     )
-    user = position_db_connector.get_object(User, position.user_id)
-    await _invalidate_user_positions_cache(user.wallet_id if user else None)
+    await _invalidate_user_positions_cache(
+        _get_wallet_id_for_position_object(position)
+    )
     return {"detail": "Successfully added extra deposit"}
 
 

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -58,7 +58,7 @@ def _get_wallet_id_for_position_object(position: object | None) -> str | None:
     if not user_id:
         return None
     user = position_db_connector.get_object(User, user_id)
-    return user.wallet_id if user else None
+    return getattr(user, "wallet_id", None) if user else None
 
 @router.get(
     "/api/get-multipliers",

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -25,7 +25,8 @@ from web_app.contract_tools.mixins import DashboardMixin, DepositMixin, Position
 from web_app.db.crud import PositionDBConnector, TransactionDBConnector
 from web_app.api.dependencies import get_stellar_client
 from web_app.contract_tools.blockchain_call import StellarClient
-from web_app.db.models import Status, TransactionStatus
+from web_app.contract_tools.cache import delete_cache_pattern, get_cached_or_fetch
+from web_app.db.models import Status, TransactionStatus, User
 from web_app.api.rate_limiter import limiter, WRITE_LIMIT, USER_DATA_LIMIT, READ_LIMIT
 from web_app.utils.logger import get_logger
 
@@ -35,7 +36,24 @@ position_db_connector = PositionDBConnector()
 transaction_db_connector = TransactionDBConnector()
 
 PAGINATION_STEP = 10
+USER_POSITIONS_CACHE_TTL = 60
 
+
+def _user_positions_cache_key(wallet_id: str, start: int, limit: int) -> str:
+    return f"user_positions:{wallet_id}:{start}:{limit}"
+
+
+async def _invalidate_user_positions_cache(wallet_id: str | None) -> None:
+    if wallet_id:
+        await delete_cache_pattern(f"user_positions:{wallet_id}:*")
+
+
+def _get_wallet_id_for_position(position_id: UUID) -> str | None:
+    position = position_db_connector.get_position_by_id(position_id)
+    if not position:
+        return None
+    user = position_db_connector.get_object(User, position.user_id)
+    return user.wallet_id if user else None
 
 @router.get(
     "/api/get-multipliers",
@@ -93,6 +111,7 @@ async def create_position_with_transaction_data(
         form_data.amount,
         form_data.multiplier,
     )
+    await _invalidate_user_positions_cache(form_data.wallet_id)
     borrowing_token = "USDC"
     if form_data.token_symbol == "USDC":
         borrowing_token = "XLM"
@@ -170,10 +189,12 @@ async def close_position(request: Request, position_id: UUID, transaction_hash: 
     if not transaction_hash:
         raise HTTPException(status_code=400, detail="Transaction hash is required")
 
+    wallet_id = _get_wallet_id_for_position(position_id)
     position_status = position_db_connector.close_position(str(position_id))
     position_db_connector.save_transaction(
         position_id=position_id, status="closed", transaction_hash=transaction_hash
     )
+    await _invalidate_user_positions_cache(wallet_id)
     return position_status
 
 
@@ -225,6 +246,8 @@ async def open_position(request: Request, position_id: str, transaction_hash: st
 
     try:
         position_db_connector.write_to_db(outbox_event)
+        user = position_db_connector.get_object(User, position.user_id)
+        await _invalidate_user_positions_cache(user.wallet_id if user else None)
     except Exception as e:
         logger.error("failed_to_write_outbox_event", error=str(e))
         raise HTTPException(status_code=500, detail="Failed to queue position opening")
@@ -347,6 +370,8 @@ async def add_extra_deposit(
     transaction_db_connector.create_transaction(
         position_id, data.transaction_hash, status=TransactionStatus.EXTRA_DEPOSIT.value
     )
+    user = position_db_connector.get_object(User, position.user_id)
+    await _invalidate_user_positions_cache(user.wallet_id if user else None)
     return {"detail": "Successfully added extra deposit"}
 
 
@@ -375,14 +400,24 @@ async def get_user_positions(
     if not wallet_id:
         raise HTTPException(status_code=400, detail="Wallet ID is required")
 
-    positions = position_db_connector.get_all_positions_by_wallet_id(
-        wallet_id, start=start, limit=limit
-    )
-    total_positions = position_db_connector.get_count_positions_by_wallet_id(wallet_id)
+    cache_key = _user_positions_cache_key(wallet_id, start, limit)
 
-    return UserPositionHistoryResponse(
-        positions=positions,
-        total_count=total_positions,
+    async def fetch_user_positions() -> dict:
+        positions = position_db_connector.get_all_positions_by_wallet_id(
+            wallet_id, start=start, limit=limit
+        )
+        total_positions = position_db_connector.get_count_positions_by_wallet_id(
+            wallet_id
+        )
+        return UserPositionHistoryResponse(
+            positions=positions,
+            total_count=total_positions,
+        ).model_dump(mode="json")
+
+    return await get_cached_or_fetch(
+        cache_key,
+        ttl=USER_POSITIONS_CACHE_TTL,
+        fetch_fn=fetch_user_positions,
     )
 
 

--- a/quantara/web_app/contract_tools/cache.py
+++ b/quantara/web_app/contract_tools/cache.py
@@ -52,3 +52,21 @@ async def get_cached_or_fetch(
         return value
     finally:
         await client.close()
+
+
+async def delete_cache_pattern(pattern: str) -> None:
+    """Delete cached entries matching a Redis SCAN pattern."""
+    pool = await get_redis_pool()
+    client = redis.Redis(connection_pool=pool)
+    try:
+        cursor = 0
+        while True:
+            cursor, keys = await client.scan(cursor=cursor, match=pattern, count=100)
+            if keys:
+                await client.delete(*keys)
+            if cursor == 0:
+                break
+    except Exception as exc:
+        logger.warning("Cache invalidation failed for %s: %s", pattern, exc)
+    finally:
+        await client.close()

--- a/quantara/web_app/tests/test_user_positions_cache_static.py
+++ b/quantara/web_app/tests/test_user_positions_cache_static.py
@@ -23,7 +23,9 @@ def test_position_lifecycle_invalidates_user_positions_cache():
     assert "await _invalidate_user_positions_cache(form_data.wallet_id)" in POSITION_SOURCE
     assert "wallet_id = _get_wallet_id_for_position(position_id)" in POSITION_SOURCE
     assert "await _invalidate_user_positions_cache(wallet_id)" in POSITION_SOURCE
-    assert "await _invalidate_user_positions_cache(user.wallet_id if user else None)" in POSITION_SOURCE
+    assert "def _get_wallet_id_for_position_object(position: object | None)" in POSITION_SOURCE
+    assert "getattr(position, \\"user_id\\", None)" in POSITION_SOURCE
+    assert "_get_wallet_id_for_position_object(position)" in POSITION_SOURCE
 
 
 def test_cache_helper_supports_pattern_invalidation():

--- a/quantara/web_app/tests/test_user_positions_cache_static.py
+++ b/quantara/web_app/tests/test_user_positions_cache_static.py
@@ -24,7 +24,7 @@ def test_position_lifecycle_invalidates_user_positions_cache():
     assert "wallet_id = _get_wallet_id_for_position(position_id)" in POSITION_SOURCE
     assert "await _invalidate_user_positions_cache(wallet_id)" in POSITION_SOURCE
     assert "def _get_wallet_id_for_position_object(position: object | None)" in POSITION_SOURCE
-    assert "getattr(position, \\"user_id\\", None)" in POSITION_SOURCE
+    assert 'getattr(position, "user_id", None)' in POSITION_SOURCE
     assert "_get_wallet_id_for_position_object(position)" in POSITION_SOURCE
 
 

--- a/quantara/web_app/tests/test_user_positions_cache_static.py
+++ b/quantara/web_app/tests/test_user_positions_cache_static.py
@@ -1,0 +1,33 @@
+"""Static coverage for user-position caching wiring."""
+
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1] / "api"
+CONTRACT_TOOLS_ROOT = Path(__file__).resolve().parents[1] / "contract_tools"
+POSITION_SOURCE = (API_ROOT / "position.py").read_text(encoding="utf-8")
+CACHE_SOURCE = (CONTRACT_TOOLS_ROOT / "cache.py").read_text(encoding="utf-8")
+
+
+def test_user_positions_endpoint_uses_wallet_scoped_cache():
+    assert "USER_POSITIONS_CACHE_TTL = 60" in POSITION_SOURCE
+    assert "def _user_positions_cache_key(wallet_id: str, start: int, limit: int)" in POSITION_SOURCE
+    assert 'return f"user_positions:{wallet_id}:{start}:{limit}"' in POSITION_SOURCE
+    assert "await get_cached_or_fetch(" in POSITION_SOURCE
+    assert "ttl=USER_POSITIONS_CACHE_TTL" in POSITION_SOURCE
+    assert "fetch_fn=fetch_user_positions" in POSITION_SOURCE
+
+
+def test_position_lifecycle_invalidates_user_positions_cache():
+    assert "async def _invalidate_user_positions_cache" in POSITION_SOURCE
+    assert 'await delete_cache_pattern(f"user_positions:{wallet_id}:*")' in POSITION_SOURCE
+    assert "await _invalidate_user_positions_cache(form_data.wallet_id)" in POSITION_SOURCE
+    assert "wallet_id = _get_wallet_id_for_position(position_id)" in POSITION_SOURCE
+    assert "await _invalidate_user_positions_cache(wallet_id)" in POSITION_SOURCE
+    assert "await _invalidate_user_positions_cache(user.wallet_id if user else None)" in POSITION_SOURCE
+
+
+def test_cache_helper_supports_pattern_invalidation():
+    assert "async def delete_cache_pattern(pattern: str)" in CACHE_SOURCE
+    assert "await client.scan(cursor=cursor, match=pattern, count=100)" in CACHE_SOURCE
+    assert "await client.delete(*keys)" in CACHE_SOURCE
+    assert "Cache invalidation failed" in CACHE_SOURCE

--- a/quantara/web_app/tests/test_user_positions_cache_static.py
+++ b/quantara/web_app/tests/test_user_positions_cache_static.py
@@ -26,6 +26,7 @@ def test_position_lifecycle_invalidates_user_positions_cache():
     assert "def _get_wallet_id_for_position_object(position: object | None)" in POSITION_SOURCE
     assert 'getattr(position, "user_id", None)' in POSITION_SOURCE
     assert 'getattr(user, "wallet_id", None)' in POSITION_SOURCE
+    assert "if not isinstance(user_id, UUID):" in POSITION_SOURCE
     assert "_get_wallet_id_for_position_object(position)" in POSITION_SOURCE
 
 

--- a/quantara/web_app/tests/test_user_positions_cache_static.py
+++ b/quantara/web_app/tests/test_user_positions_cache_static.py
@@ -25,6 +25,7 @@ def test_position_lifecycle_invalidates_user_positions_cache():
     assert "await _invalidate_user_positions_cache(wallet_id)" in POSITION_SOURCE
     assert "def _get_wallet_id_for_position_object(position: object | None)" in POSITION_SOURCE
     assert 'getattr(position, "user_id", None)' in POSITION_SOURCE
+    assert 'getattr(user, "wallet_id", None)' in POSITION_SOURCE
     assert "_get_wallet_id_for_position_object(position)" in POSITION_SOURCE
 
 


### PR DESCRIPTION
Closes #237

## Summary
- cache `/api/user-positions/{wallet_id}` responses for 60 seconds using wallet/start/limit scoped keys
- add Redis pattern invalidation for user-position cache entries
- invalidate the user-position cache when positions are created, opened, closed, or extra deposits are recorded

## Validation
- Static API validation: branch diff is 0 behind upstream main and changes only cache/user-position API wiring plus static coverage
- GitHub Actions will run the project gates for this PR
- Not run locally: project dependency/toolchain execution is intentionally avoided in this workspace