### PR TITLE
Scrub bug report text before Sentry ingest

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -37,6 +37,7 @@ from web_app.api.metrics import router as metrics_router, PrometheusMiddleware
 from web_app.api.pausable import protocol_pause_middleware
 from web_app.api.pausable import router as pausable_router
 from web_app.api.walletconnect import router as walletconnect_router
+from web_app.api.sentry_hooks import before_send
 from web_app.config_validator import assert_valid_config
 from web_app.api.middleware import AccessLogMiddleware, MaxBodySizeMiddleware, SecurityHeadersMiddleware
 from web_app.db.database import init_db
@@ -101,6 +102,7 @@ async def lifespan(app: FastAPI):
         sentry_sdk.init(
             dsn=os.getenv("SENTRY_DSN"),
             traces_sampler=custom_traces_sampler,
+            before_send=before_send,
             _experiments={
                 "continuous_profiling_auto_start": True,
             },

--- a/quantara/web_app/api/sentry_hooks.py
+++ b/quantara/web_app/api/sentry_hooks.py
@@ -1,0 +1,25 @@
+"""Sentry hooks that enforce safe operator-facing event payloads."""
+
+from typing import Any
+
+from web_app.utils.scrub import scrub_user_text_for_sentry
+
+BUG_REPORT_CONTEXT = "bug_report"
+DESCRIPTION_FIELD = "description"
+
+
+def _scrub_description(mapping: Any) -> None:
+    if isinstance(mapping, dict) and DESCRIPTION_FIELD in mapping:
+        mapping[DESCRIPTION_FIELD] = scrub_user_text_for_sentry(
+            mapping[DESCRIPTION_FIELD]
+        )
+
+
+def before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+    """Scrub bug report text before Sentry persists an event."""
+    contexts = event.get("contexts")
+    if isinstance(contexts, dict):
+        _scrub_description(contexts.get(BUG_REPORT_CONTEXT))
+
+    _scrub_description(event.get("extra"))
+    return event

--- a/quantara/web_app/api/user.py
+++ b/quantara/web_app/api/user.py
@@ -29,6 +29,7 @@ from web_app.db.crud import (
 
 from web_app.api.rate_limiter import limiter, WRITE_LIMIT, USER_DATA_LIMIT, READ_LIMIT
 from web_app.utils.logger import get_logger
+from web_app.utils.scrub import scrub_user_text_for_sentry
 
 logger = get_logger(__name__)
 router = APIRouter()  # Initialize the router
@@ -313,23 +314,26 @@ async def save_bug_report(request: Request, report: BugReportRequest) -> BugRepo
                 status_code=422, detail="Wallet ID and bug description cannot be empty"
             )
 
+        safe_wallet_id = scrub_user_text_for_sentry(report.wallet_id, max_length=128)
+        safe_description = scrub_user_text_for_sentry(report.bug_description)
+
         sentry_sdk.set_user(
-            {"wallet_id": report.wallet_id, "telegram_id": report.telegram_id}
+            {"wallet_id": safe_wallet_id, "telegram_id": report.telegram_id}
         )
 
         sentry_sdk.set_context(
             "bug_report",
             {
-                "wallet_id": report.wallet_id,
+                "wallet_id": safe_wallet_id,
                 "telegram_id": report.telegram_id,
-                "description": report.bug_description,
+                "description": safe_description,
             },
         )
 
         sentry_sdk.capture_message(
-            f"Bug Report from {report.wallet_id}",
+            f"Bug Report from {safe_wallet_id}",
             level="error",
-            extras={"description": report.bug_description},
+            extras={"description": safe_description},
         )
 
         return BugReportResponse(message="Bug report submitted successfully")

--- a/quantara/web_app/tests/test_sentry_bug_report_scrub_static.py
+++ b/quantara/web_app/tests/test_sentry_bug_report_scrub_static.py
@@ -1,0 +1,36 @@
+"""Static checks for Sentry bug-report sanitization wiring."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+USER_API = (ROOT / "api" / "user.py").read_text()
+MAIN_API = (ROOT / "api" / "main.py").read_text()
+SCRUB = (ROOT / "utils" / "scrub.py").read_text()
+HOOKS = (ROOT / "api" / "sentry_hooks.py").read_text()
+
+
+def test_bug_report_endpoint_sends_only_scrubbed_description_to_sentry():
+    assert "safe_description = scrub_user_text_for_sentry(report.bug_description)" in USER_API
+    assert 'extras={"description": safe_description}' in USER_API
+    assert '"description": report.bug_description' not in USER_API
+    assert 'extras={"description": report.bug_description}' not in USER_API
+
+
+def test_sentry_before_send_hook_is_registered():
+    assert "from web_app.api.sentry_hooks import before_send" in MAIN_API
+    assert "before_send=before_send" in MAIN_API
+
+
+def test_scrubber_escapes_html_and_enforces_cap_with_marker():
+    assert "html.escape(text, quote=True)" in SCRUB
+    assert "MAX_SENTRY_TEXT_LENGTH = 1000" in SCRUB
+    assert 'TRUNCATION_MARKER = "...[truncated]"' in SCRUB
+    assert "text[: max_length - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER" in SCRUB
+
+
+def test_before_send_enforces_scrub_on_context_and_extra_payloads():
+    assert 'BUG_REPORT_CONTEXT = "bug_report"' in HOOKS
+    assert 'DESCRIPTION_FIELD = "description"' in HOOKS
+    assert 'contexts.get(BUG_REPORT_CONTEXT)' in HOOKS
+    assert 'event.get("extra")' in HOOKS
+    assert "scrub_user_text_for_sentry(" in HOOKS

--- a/quantara/web_app/utils/scrub.py
+++ b/quantara/web_app/utils/scrub.py
@@ -1,0 +1,22 @@
+"""Helpers for removing unsafe user-controlled text from operator telemetry."""
+
+import html
+from typing import Any
+
+MAX_SENTRY_TEXT_LENGTH = 1000
+TRUNCATION_MARKER = "...[truncated]"
+
+
+def scrub_user_text_for_sentry(
+    value: Any,
+    max_length: int = MAX_SENTRY_TEXT_LENGTH,
+) -> str:
+    """Return bounded, HTML-escaped text safe to render in Sentry UI fields."""
+    text = "" if value is None else str(value)
+    if max_length < len(TRUNCATION_MARKER):
+        raise ValueError("max_length must fit the truncation marker")
+
+    if len(text) > max_length:
+        text = text[: max_length - len(TRUNCATION_MARKER)] + TRUNCATION_MARKER
+
+    return html.escape(text, quote=True)


### PR DESCRIPTION
## Summary
- add a bounded `html.escape`-based scrubber for user-controlled Sentry text
- add a Sentry `before_send` hook that re-scrubs bug-report context and event extra descriptions before persistence
- send only scrubbed wallet/description values from `/api/save-bug-report`
- add static coverage for endpoint wiring, hook registration, escaping, and truncation markers

## Testing
- Not run locally: this workspace avoids installing/running project dependencies or invasive toolchains.
- Added static regression checks under `quantara/web_app/tests/test_sentry_bug_report_scrub_static.py` for CI.

Closes #199