### PR TITLE
Reuse aiohttp sessions per client instance

### DIFF
--- a/quantara/web_app/api/dependencies.py
+++ b/quantara/web_app/api/dependencies.py
@@ -2,15 +2,21 @@
 API dependencies for the Quantara FastAPI application.
 """
 
+from collections.abc import AsyncIterator
+
 from web_app.api.wallet_auth import verify_wallet_signature
 from web_app.contract_tools.blockchain_call import StellarClient
 
 
-def get_stellar_client() -> StellarClient:
+async def get_stellar_client() -> AsyncIterator[StellarClient]:
     """
-    FastAPI dependency that returns a StellarClient instance.
+    FastAPI dependency that returns and closes a StellarClient instance.
     """
-    return StellarClient()
+    client = StellarClient()
+    try:
+        yield client
+    finally:
+        await client.close()
 
 
 __all__ = ["get_stellar_client", "verify_wallet_signature"]

--- a/quantara/web_app/contract_tools/api_request.py
+++ b/quantara/web_app/contract_tools/api_request.py
@@ -17,6 +17,22 @@ class APIRequest:
 
     def __init__(self, base_url: str):
         self.base_url = base_url
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(headers=self.DEFAULT_HEADER)
+        return self._session
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
 
     async def fetch(self, endpoint: str, params: dict = None, headers: dict = None):
         """
@@ -33,13 +49,13 @@ class APIRequest:
         if headers:
             request_headers.update(headers)
 
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}{endpoint}"
-            async with session.get(
-                url, params=params, headers=request_headers
-            ) as response:
-                response.raise_for_status()
-                return await response.json()
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        async with session.get(
+            url, params=params, headers=request_headers
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
 
     async def post(self, endpoint: str, data: dict = None, headers: dict = None) -> dict:
         """
@@ -51,11 +67,11 @@ class APIRequest:
         :return: The response from the API as JSON.
         :raises aiohttp.ClientError: On network or HTTP errors.
         """
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}{endpoint}"
-            async with session.post(url, json=data, headers=headers) as response:
-                response.raise_for_status()  # Raise an exception for bad status codes
-                return await response.json()
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        async with session.post(url, json=data, headers=headers) as response:
+            response.raise_for_status()  # Raise an exception for bad status codes
+            return await response.json()
 
     async def fetch_text(
         self, endpoint: str, params: dict = None, headers: dict = None
@@ -69,11 +85,11 @@ class APIRequest:
         :return: The response from the API as text.
         :raises aiohttp.ClientError: On network or HTTP errors.
         """
-        async with aiohttp.ClientSession() as session:
-            url = f"{self.base_url}{endpoint}"
-            async with session.get(url, params=params, headers=headers) as response:
-                response.raise_for_status()  # Raise an exception for bad status codes
-                return await response.text()
+        session = await self._get_session()
+        url = f"{self.base_url}{endpoint}"
+        async with session.get(url, params=params, headers=headers) as response:
+            response.raise_for_status()  # Raise an exception for bad status codes
+            return await response.text()
 
 
 # Example usage:

--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -67,7 +67,6 @@ class StellarClient:
 
     async def __aexit__(self, exc_type, exc, tb):
         await self.close()
-
     # ------------------------------------------------------------------ #
     #  Balance queries via Horizon REST API (async with aiohttp)
     # ------------------------------------------------------------------ #
@@ -93,11 +92,11 @@ class StellarClient:
             session = await self._get_session()
             async with session.get(url) as response:
                 if response.status == 404:
-                        logger.info("horizon_account_not_found", account=holder_address)
-                        return "0"
-                    if response.status != 200:
-                        logger.warning("horizon_unexpected_status", status=response.status, url=url)
-                        return "0"
+                    logger.info("horizon_account_not_found", account=holder_address)
+                    return "0"
+                if response.status != 200:
+                    logger.warning("horizon_unexpected_status", status=response.status, url=url)
+                    return "0"
                 account = await response.json()
         except aiohttp.ClientError as exc:
             logger.error("horizon_network_error", account=holder_address, error=str(exc))
@@ -134,17 +133,17 @@ class StellarClient:
             session = await self._get_session()
             async with session.get(url) as response:
                 if response.status == 404:
-                        logger.info(
-                            "Account %s not found on Stellar network",
-                            holder_address,
-                        )
-                        return None
-                    if response.status != 200:
-                        logger.warning(
-                            "Horizon returned %d for %s", response.status, url
-                        )
-                        return None
-                    return await response.json()
+                    logger.info(
+                        "Account %s not found on Stellar network",
+                        holder_address,
+                    )
+                    return None
+                if response.status != 200:
+                    logger.warning(
+                        "Horizon returned %d for %s", response.status, url
+                    )
+                    return None
+                return await response.json()
         except aiohttp.ClientError as exc:
             logger.error("Network error fetching account %s: %s", holder_address, exc)
             return None
@@ -263,11 +262,11 @@ class StellarClient:
             session = await self._get_session()
             async with session.post(rpc_url, json=payload) as response:
                 if response.status == 200:
-                        data = await response.json()
-                        if "error" in data:
-                            logger.warning("rpc_contract_error", contract_id=contract_id, error=data["error"])
-                            return False
-                        return "result" in data
+                    data = await response.json()
+                    if "error" in data:
+                        logger.warning("rpc_contract_error", contract_id=contract_id, error=data["error"])
+                        return False
+                    return "result" in data
                 logger.warning("rpc_unexpected_status", status=response.status, contract_id=contract_id)
                 return False
         except aiohttp.ClientError as e:

--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -51,6 +51,22 @@ class StellarClient:
 
         if not self.horizon_url:
             raise ValueError("STELLAR_HORIZON_URL environment variable is not set")
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
 
     # ------------------------------------------------------------------ #
     #  Balance queries via Horizon REST API (async with aiohttp)
@@ -74,8 +90,8 @@ class StellarClient:
             return "0"
         url = f"{self.horizon_url.rstrip('/')}/accounts/{holder_address}"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
+            session = await self._get_session()
+            async with session.get(url) as response:
                     if response.status == 404:
                         logger.info("horizon_account_not_found", account=holder_address)
                         return "0"
@@ -115,8 +131,8 @@ class StellarClient:
             return None
         url = f"{self.horizon_url.rstrip('/')}/accounts/{holder_address}"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
+            session = await self._get_session()
+            async with session.get(url) as response:
                     if response.status == 404:
                         logger.info(
                             "Account %s not found on Stellar network",
@@ -244,8 +260,8 @@ class StellarClient:
                     "key": _SOROBAN_WASM_HASH_KEY,  # base64 "wasm_hash"
                 },
             }
-            async with aiohttp.ClientSession() as session:
-                async with session.post(rpc_url, json=payload) as response:
+            session = await self._get_session()
+            async with session.post(rpc_url, json=payload) as response:
                     if response.status == 200:
                         data = await response.json()
                         if "error" in data:

--- a/quantara/web_app/contract_tools/blockchain_call.py
+++ b/quantara/web_app/contract_tools/blockchain_call.py
@@ -92,13 +92,13 @@ class StellarClient:
         try:
             session = await self._get_session()
             async with session.get(url) as response:
-                    if response.status == 404:
+                if response.status == 404:
                         logger.info("horizon_account_not_found", account=holder_address)
                         return "0"
                     if response.status != 200:
                         logger.warning("horizon_unexpected_status", status=response.status, url=url)
                         return "0"
-                    account = await response.json()
+                account = await response.json()
         except aiohttp.ClientError as exc:
             logger.error("horizon_network_error", account=holder_address, error=str(exc))
             return "0"
@@ -133,7 +133,7 @@ class StellarClient:
         try:
             session = await self._get_session()
             async with session.get(url) as response:
-                    if response.status == 404:
+                if response.status == 404:
                         logger.info(
                             "Account %s not found on Stellar network",
                             holder_address,
@@ -262,14 +262,14 @@ class StellarClient:
             }
             session = await self._get_session()
             async with session.post(rpc_url, json=payload) as response:
-                    if response.status == 200:
+                if response.status == 200:
                         data = await response.json()
                         if "error" in data:
                             logger.warning("rpc_contract_error", contract_id=contract_id, error=data["error"])
                             return False
                         return "result" in data
-                    logger.warning("rpc_unexpected_status", status=response.status, contract_id=contract_id)
-                    return False
+                logger.warning("rpc_unexpected_status", status=response.status, contract_id=contract_id)
+                return False
         except aiohttp.ClientError as e:
             logger.error("rpc_network_error", contract_id=contract_id, error=str(e))
             return False

--- a/quantara/web_app/tests/test_aiohttp_session_reuse_static.py
+++ b/quantara/web_app/tests/test_aiohttp_session_reuse_static.py
@@ -1,0 +1,33 @@
+"""Static checks for per-instance aiohttp session reuse."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BLOCKCHAIN_CALL = (ROOT / "contract_tools" / "blockchain_call.py").read_text()
+API_REQUEST = (ROOT / "contract_tools" / "api_request.py").read_text()
+DEPENDENCIES = (ROOT / "api" / "dependencies.py").read_text()
+
+
+def test_stellar_client_reuses_one_session_and_exposes_close():
+    assert "self._session: aiohttp.ClientSession | None = None" in BLOCKCHAIN_CALL
+    assert "async def _get_session(self) -> aiohttp.ClientSession" in BLOCKCHAIN_CALL
+    assert "self._session = aiohttp.ClientSession()" in BLOCKCHAIN_CALL
+    assert "async def close(self) -> None" in BLOCKCHAIN_CALL
+    assert "await self._session.close()" in BLOCKCHAIN_CALL
+    assert BLOCKCHAIN_CALL.count("aiohttp.ClientSession(") == 1
+    assert "async with aiohttp.ClientSession" not in BLOCKCHAIN_CALL
+
+
+def test_api_request_reuses_one_session_and_exposes_close():
+    assert "self._session: aiohttp.ClientSession | None = None" in API_REQUEST
+    assert "async def _get_session(self) -> aiohttp.ClientSession" in API_REQUEST
+    assert "self._session = aiohttp.ClientSession(headers=self.DEFAULT_HEADER)" in API_REQUEST
+    assert "async def close(self) -> None" in API_REQUEST
+    assert API_REQUEST.count("aiohttp.ClientSession(") == 1
+    assert "async with aiohttp.ClientSession" not in API_REQUEST
+
+
+def test_fastapi_dependency_closes_stellar_client_after_request():
+    assert "async def get_stellar_client() -> AsyncIterator[StellarClient]" in DEPENDENCIES
+    assert "yield client" in DEPENDENCIES
+    assert "await client.close()" in DEPENDENCIES


### PR DESCRIPTION
## Summary
- reuse one lazy `aiohttp.ClientSession` per `StellarClient` instance for Horizon/RPC calls
- reuse one lazy default-header session per `APIRequest` instance
- expose `close()` and async context-manager helpers for both clients
- convert the FastAPI `get_stellar_client` dependency to yield and close the client after each request
- add static regression coverage that blocks per-call session construction from returning

## Testing
- Not run locally: this workspace avoids installing/running project dependencies or invasive toolchains.
- Added static regression checks under `quantara/web_app/tests/test_aiohttp_session_reuse_static.py` for CI.

Closes #258