### PR TITLE
Route frontend console output through dev logger

### DIFF
--- a/quantara/frontend/src/App.jsx
+++ b/quantara/frontend/src/App.jsx
@@ -29,6 +29,7 @@ import Leaderboard from '@/pages/leaderboard/Leaderboard';
 import AddressBookPage from '@/pages/address-book/AddressBookPage';
 import NotFound from '@/pages/not-found/NotFound';
 import { initTelemetry } from '@/services/telemetry';
+import { logger } from '@/utils/logger';
 
 function App() {
   const { setWalletId, removeWalletId } = useWalletStore();
@@ -84,7 +85,7 @@ function App() {
           window.Telegram.WebApp.ready();
         })
         .catch((error) => {
-          console.error('Error getting Telegram user wallet ID:', error);
+          logger.error('Error getting Telegram user wallet ID:', error);
           notify('Error loading wallet', 'error');
           window.Telegram.WebApp.ready();
         });

--- a/quantara/frontend/src/hooks/useClosePosition.js
+++ b/quantara/frontend/src/hooks/useClosePosition.js
@@ -3,6 +3,7 @@ import { axiosInstance } from '../utils/axios';
 import { closePosition } from '../services/transaction';
 import { useWalletStore } from '../stores/useWalletStore';
 import { notify } from '../components/layout/notifier/Notifier';
+import { logger } from '@/utils/logger';
 
 /**
  * Hook for closing a user's leveraged position.
@@ -18,7 +19,7 @@ export const useClosePosition = () => {
   return useMutation({
     mutationFn: async () => {
       if (!walletId) {
-        console.error('closePositionEvent: walletId is undefined');
+        logger.error('closePositionEvent: walletId is undefined');
         return;
       }
       const response = await axiosInstance.get('/api/get-repay-data', {
@@ -27,7 +28,7 @@ export const useClosePosition = () => {
         },
       });
       const transactionResult = await closePosition(response.data);
-      console.log('TransactionResult', transactionResult);
+      logger.log('TransactionResult', transactionResult);
       await axiosInstance.get('/api/close-position', {
         params: {
           position_id: response.data.position_id,
@@ -36,7 +37,7 @@ export const useClosePosition = () => {
       });
     },
     onError: (error) => {
-      console.error('Error during closePositionEvent', error);
+      logger.error('Error during closePositionEvent', error);
       notify(`Error during closePositionEvent: ${error.message}`, 'error');
     },
   });

--- a/quantara/frontend/src/hooks/useConnectWallet.js
+++ b/quantara/frontend/src/hooks/useConnectWallet.js
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { notify } from '../components/layout/notifier/Notifier';
 import { connectWallet } from '../services/wallet';
 import { startWalletConnectTransaction } from '../services/telemetry';
+import { logger } from '@/utils/logger';
 
 /**
  * Hook for connecting to the Freighter Stellar wallet.
@@ -34,7 +35,7 @@ export const useConnectWallet = (setWalletId) => {
       setWalletId(publicKey);
     },
     onError: (error) => {
-      console.error('Wallet connection failed:', error);
+      logger.error('Wallet connection failed:', error);
       notify(error.message || 'Failed to connect wallet. Please try again.', 'error');
     },
   });

--- a/quantara/frontend/src/hooks/useDashboardData.js
+++ b/quantara/frontend/src/hooks/useDashboardData.js
@@ -6,6 +6,7 @@ import XlmIcon from '@/assets/icons/xlm.svg?react';
 import UsdIcon from '@/assets/icons/usd_coin.svg?react';
 import CollateralIcon from '@/assets/icons/collateral_dynamic.svg?react';
 import BorrowIcon from '@/assets/icons/borrow_dynamic.svg?react';
+import { logger } from '@/utils/logger';
 
 /**
  * Fetch dashboard data from the backend for a given wallet.
@@ -78,7 +79,7 @@ const useDashboardData = () => {
         position_id,
       };
     },
-    onError: (error) => console.error('Error fetching dashboard data:', error),
+    onError: (error) => logger.error('Error fetching dashboard data:', error),
   });
 
   return {

--- a/quantara/frontend/src/hooks/useHealthRatio.js
+++ b/quantara/frontend/src/hooks/useHealthRatio.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { axiosInstance } from '../utils/axios';
+import { logger } from '@/utils/logger';
 
 /** Token configuration for health factor calculation */
 const TOKEN_CONFIG = {
@@ -68,7 +69,7 @@ export const useHealthFactor = (selectedToken, tokenAmount, selectedMultiplier) 
 
       return Number(healthFactorValue.toFixed(6));
     } catch (error) {
-      console.error('Error calculating health factor:', error);
+      logger.error('Error calculating health factor:', error);
       return 0;
     }
   };

--- a/quantara/frontend/src/hooks/usePositionHistory.js
+++ b/quantara/frontend/src/hooks/usePositionHistory.js
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { axiosInstance } from '../utils/axios';
 import { formatDate } from '../utils/formatDate';
 import { useWalletStore } from '../stores/useWalletStore';
+import { logger } from '@/utils/logger';
 
 /**
  * Fetch paginated position history from the backend.
@@ -46,7 +47,7 @@ const usePositionHistoryTable = (currentPage, positionsOnPage) => {
     queryFn: () => fetchPositionHistoryTable(walletId, (currentPage - 1) * positionsOnPage, positionsOnPage),
     enabled: !!walletId,
     onError: (err) => {
-      console.error('Error during fetching position history:', err);
+      logger.error('Error during fetching position history:', err);
     },
     select: (response) => ({
       ...response,

--- a/quantara/frontend/src/pages/DashboardLayout.jsx
+++ b/quantara/frontend/src/pages/DashboardLayout.jsx
@@ -8,6 +8,7 @@ import withdrawIcon from '@/assets/icons/withdraw.svg';
 import formIcon from '@/assets/icons/form-icon.svg';
 import addressBookIcon from '@/assets/icons/dashboard-icon.svg';
 import { useCheckMobile } from '@/hooks/useCheckMobile';
+import { logger } from '@/utils/logger';
 
 const dashboardItems = [
   {
@@ -50,7 +51,7 @@ const dashboardItems = [
 
 export default function DashboardLayout({ children, title = 'Position' }) {
   const isMobile = useCheckMobile();
-  console.log(formIcon)
+  logger.log(formIcon)
   return (
     <div className="flex min-h-screen w-screen md:justify-center lg:ml-[372px] lg:w-[calc(100vw-372px)]">
       <Sidebar items={dashboardItems} />

--- a/quantara/frontend/src/pages/not-found/NotFound.jsx
+++ b/quantara/frontend/src/pages/not-found/NotFound.jsx
@@ -14,8 +14,8 @@ const NotFound = () => {
 
   useEffect(() => {
     // Log the unknown route to make it easier to spot broken links
-    // in the browser console. Only log in development to avoid noise
-    // in production browser consoles.
+    // in the browser devtools. Only log in development to avoid noise
+    // in production browser devtoolss.
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
       logger.warn(`NotFound: no route matches ${location.pathname}`);

--- a/quantara/frontend/src/pages/not-found/NotFound.jsx
+++ b/quantara/frontend/src/pages/not-found/NotFound.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import './NotFound.css';
+import { logger } from '@/utils/logger';
 
 /**
  * NotFound page displayed for undefined routes.
@@ -17,7 +18,7 @@ const NotFound = () => {
     // in production browser consoles.
     if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
-      console.warn(`NotFound: no route matches ${location.pathname}`);
+      logger.warn(`NotFound: no route matches ${location.pathname}`);
     }
   }, [location.pathname]);
 

--- a/quantara/frontend/src/services/contract.js
+++ b/quantara/frontend/src/services/contract.js
@@ -23,6 +23,7 @@ import { getSorobanServer, pollForTransaction } from './soroban';
 import { SOROBAN_WASM_HASH } from '../utils/constants';
 import { axiosInstance, getAuthHeaders } from '../utils/axios';
 import { notify, ToastWithLink } from '../components/layout/notifier/Notifier';
+import { logger } from '@/utils/logger';
 
 /**
  * Build a Stellar Expert block explorer URL for a Soroban contract.
@@ -53,7 +54,7 @@ export async function deployContract(walletId) {
     throw new Error('Please connect your Freighter wallet first');
   }
 
-  console.log('Deploying Soroban contract for wallet:', walletId);
+  logger.log('Deploying Soroban contract for wallet:', walletId);
 
   // ------------------------------------------------------------------ //
   //  1. Resolve the WASM hash (env var → backend fallback)
@@ -146,7 +147,7 @@ export async function deployContract(walletId) {
       throw new Error(`Invalid contract address returned: ${contractAddress}`);
     }
 
-    console.log('Soroban contract deployed at address:', contractAddress);
+    logger.log('Soroban contract deployed at address:', contractAddress);
 
     notify(
       ToastWithLink(
@@ -182,16 +183,16 @@ export async function deployContract(walletId) {
  */
 export async function checkAndDeployContract(walletId) {
   try {
-    console.log('Checking if contract is deployed for wallet ID:', walletId);
+    logger.log('Checking if contract is deployed for wallet ID:', walletId);
     const response = await axiosInstance.get(`/api/check-user?wallet_id=${walletId}`);
-    console.log('Backend response:', response.data);
+    logger.log('Backend response:', response.data);
 
     if (!response.data.is_contract_deployed) {
-      console.log('Contract not deployed. Deploying...');
+      logger.log('Contract not deployed. Deploying...');
       const result = await deployContract(walletId);
       const contractAddress = result.contractAddress;
 
-      console.log('Contract address:', contractAddress);
+      logger.log('Contract address:', contractAddress);
 
       // Update the backend with deployment info (requires wallet auth headers)
       const authHeaders = await getAuthHeaders(walletId);
@@ -199,12 +200,12 @@ export async function checkAndDeployContract(walletId) {
         wallet_id: walletId,
         contract_address: contractAddress,
       }, { headers: authHeaders });
-      console.log('Backend updated with deployment information.');
+      logger.log('Backend updated with deployment information.');
     } else {
-      console.log('Contract is already deployed for wallet ID:', walletId);
+      logger.log('Contract is already deployed for wallet ID:', walletId);
     }
   } catch (error) {
-    console.error('Error checking contract status:', error);
+    logger.error('Error checking contract status:', error);
     throw error;
   }
 }

--- a/quantara/frontend/src/services/soroban.js
+++ b/quantara/frontend/src/services/soroban.js
@@ -17,6 +17,7 @@ import {
 } from '@stellar/stellar-sdk';
 import { getWalletPublicKey, signStellarTransaction, getNetworkPassphrase } from './wallet';
 import { STELLAR_SOROBAN_RPC_URL } from '../utils/constants';
+import { logger } from '@/utils/logger';
 
 /**
  * Get a connected SorobanRPC server instance.
@@ -103,7 +104,7 @@ export async function invokeSorobanContract(contractId, methodName, args = []) {
 
   if (!SorobanRpc.isSimulationSuccess(simulation)) {
     const errorMsg = simulation?.error || 'Unknown simulation error';
-    console.error('Soroban simulation failed:', errorMsg);
+    logger.error('Soroban simulation failed:', errorMsg);
     throw new Error(`Contract simulation failed: ${errorMsg}`);
   }
 

--- a/quantara/frontend/src/services/telegram.js
+++ b/quantara/frontend/src/services/telegram.js
@@ -1,4 +1,5 @@
 import { axiosInstance } from '../utils/axios';
+import { logger } from '@/utils/logger';
 
 /**
  * Save or update a Telegram user's information in the backend.
@@ -19,7 +20,7 @@ export const saveTelegramUser = async (telegramUser, walletId) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Error saving Telegram user:', error);
+    logger.error('Error saving Telegram user:', error);
     throw error;
   }
 };
@@ -39,7 +40,7 @@ export const getTelegramUserWalletId = async (telegram_id) => {
     });
     return response.data.wallet_id;
   } catch (error) {
-    console.error('Error getting wallet ID for Telegram user:', error);
+    logger.error('Error getting wallet ID for Telegram user:', error);
     throw error;
   }
 };
@@ -61,7 +62,7 @@ export const subscribeToNotification = async (telegram_id, wallet_id) => {
 
     return response.data;
   } catch (error) {
-    console.error('Error subscribing to notifications:', error);
+    logger.error('Error subscribing to notifications:', error);
     throw error;
   }
 };
@@ -80,7 +81,7 @@ export const generateTelegramLink = async (wallet_id) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Error generating Telegram link:', error);
+    logger.error('Error generating Telegram link:', error);
     throw error;
   }
 };

--- a/quantara/frontend/src/services/telemetry.js
+++ b/quantara/frontend/src/services/telemetry.js
@@ -29,6 +29,7 @@
 
 import * as Sentry from '@sentry/react';
 import { onLCP, onCLS, onINP, onFCP, onTTFB } from 'web-vitals';
+import { logger } from '@/utils/logger';
 
 // StrKey public / secret seed: 56 chars, ed25519 base32 (A-Z, 2-7).
 // The character after the prefix ('G' or 'S') is captured by length rather
@@ -102,7 +103,7 @@ const scrubEvent = (event) => {
   } catch (err) {
     // Never let the scrubber break event submission.
     // eslint-disable-next-line no-console
-    console.debug('sentry_scrub_failed', err);
+    logger.debug('sentry_scrub_failed', err);
   }
   return event;
 };
@@ -169,7 +170,7 @@ const instrumentWebVitals = ({ sink }) => {
   const report = (metric) => {
     if (sink === console) {
       // eslint-disable-next-line no-console
-      console.debug(
+      logger.debug(
         `[web-vitals] ${metric.name}`,
         metric.value,
         metric.rating,

--- a/quantara/frontend/src/services/transaction.js
+++ b/quantara/frontend/src/services/transaction.js
@@ -13,6 +13,7 @@ import { axiosInstance, getAuthHeaders } from '../utils/axios';
 import { notify, ToastWithLink } from '../components/layout/notifier/Notifier';
 import { STELLAR_NETWORK } from '../utils/constants';
 import { startOpenPositionTransaction } from './telemetry';
+import { logger } from '@/utils/logger';
 
 /**
  * Build a Stellar Explorer URL for a transaction hash,
@@ -38,7 +39,7 @@ export async function sendTransaction(loopData, contractAddress) {
       throw new Error('Wallet is not connected');
     }
 
-    console.log('Sending loop_liquidity Soroban call:', {
+    logger.log('Sending loop_liquidity Soroban call:', {
       contractAddress,
       loopData,
     });
@@ -54,7 +55,7 @@ export async function sendTransaction(loopData, contractAddress) {
       ]
     );
 
-    console.log('loop_liquidity transaction complete:', transaction_hash);
+    logger.log('loop_liquidity transaction complete:', transaction_hash);
 
     notify(
       ToastWithLink(
@@ -67,7 +68,7 @@ export async function sendTransaction(loopData, contractAddress) {
 
     return { transaction_hash };
   } catch (error) {
-    console.error('Error sending loop_liquidity transaction:', error);
+    logger.error('Error sending loop_liquidity transaction:', error);
     throw error;
   }
 }
@@ -88,7 +89,7 @@ export async function closePosition(transactionData) {
       throw new Error('Wallet is not connected');
     }
 
-    console.log('Closing position:', transactionData);
+    logger.log('Closing position:', transactionData);
 
     const { transaction_hash } = await invokeSorobanContract(
       transactionData.contract_address,
@@ -100,7 +101,7 @@ export async function closePosition(transactionData) {
       ]
     );
 
-    console.log('close_position transaction:', transaction_hash);
+    logger.log('close_position transaction:', transaction_hash);
 
     notify(
       ToastWithLink(
@@ -113,7 +114,7 @@ export async function closePosition(transactionData) {
 
     return { transaction_hash };
   } catch (error) {
-    console.error('Error closing position:', error);
+    logger.error('Error closing position:', error);
     throw error;
   }
 }
@@ -136,7 +137,7 @@ export async function sendExtraDepositTransaction(depositData, userContractAddre
       throw new Error('Wallet is not connected');
     }
 
-    console.log('Sending extra_deposit:', { depositData, userContractAddress });
+    logger.log('Sending extra_deposit:', { depositData, userContractAddress });
 
     const { transaction_hash } = await invokeSorobanContract(
       userContractAddress,
@@ -147,7 +148,7 @@ export async function sendExtraDepositTransaction(depositData, userContractAddre
       ]
     );
 
-    console.log('extra_deposit transaction:', transaction_hash);
+    logger.log('extra_deposit transaction:', transaction_hash);
 
     notify(
       ToastWithLink(
@@ -160,7 +161,7 @@ export async function sendExtraDepositTransaction(depositData, userContractAddre
 
     return { transaction_hash };
   } catch (error) {
-    console.error('Error sending extra deposit transaction:', error);
+    logger.error('Error sending extra deposit transaction:', error);
     throw error;
   }
 }
@@ -184,7 +185,7 @@ export async function sendWithdrawAllTransaction(data, userContractAddress) {
       throw new Error('Wallet is not connected');
     }
 
-    console.log('Sending withdraw-all:', { data, userContractAddress });
+    logger.log('Sending withdraw-all:', { data, userContractAddress });
 
     // Step 1: Close the position
     const closeResult = await invokeSorobanContract(
@@ -197,7 +198,7 @@ export async function sendWithdrawAllTransaction(data, userContractAddress) {
       ]
     );
 
-    console.log('close_position done:', closeResult.transaction_hash);
+    logger.log('close_position done:', closeResult.transaction_hash);
 
     // Step 2: Withdraw each token
     const withdrawResults = [];
@@ -213,7 +214,7 @@ export async function sendWithdrawAllTransaction(data, userContractAddress) {
       withdrawResults.push(withdrawResult);
     }
 
-    console.log('Withdraw-all complete', {
+    logger.log('Withdraw-all complete', {
       closeHash: closeResult.transaction_hash,
       withdrawHashes: withdrawResults.map((r) => r.transaction_hash),
     });
@@ -231,7 +232,7 @@ export async function sendWithdrawAllTransaction(data, userContractAddress) {
       transaction_hash: closeResult.transaction_hash,
     };
   } catch (error) {
-    console.error('Error sending withdraw transaction', error);
+    logger.error('Error sending withdraw transaction', error);
     throw error;
   }
 }
@@ -267,7 +268,7 @@ export const handleTransaction = async (connectedWalletId, formData, setTokenAmo
     const response = await axiosInstance.post(`/api/create-position`, formData, { headers: authHeaders });
     const transactionData = response.data;
 
-    console.log('Position data received:', transactionData);
+    logger.log('Position data received:', transactionData);
 
     // Invoke Soroban loop_liquidity contract
     const { transaction_hash } = await sendTransaction(
@@ -286,7 +287,7 @@ export const handleTransaction = async (connectedWalletId, formData, setTokenAmo
     setTokenAmount('');
   } catch (err) {
     transaction.setStatus('internal_error');
-    console.error('Failed to create position:', err);
+    logger.error('Failed to create position:', err);
     notify(`Error: ${err.message || 'Failed to create position'}`, 'error');
   } finally {
     transaction.setStatus('ok');

--- a/quantara/frontend/src/services/wallet.jsx
+++ b/quantara/frontend/src/services/wallet.jsx
@@ -19,6 +19,7 @@ import {
 import { StrKey } from '@stellar/stellar-sdk';
 
 import { XLM_ASSET, USDC_ASSET } from '../utils/constants';
+import { logger } from '@/utils/logger';
 
 /**
  * Check if Freighter is installed in the browser.
@@ -42,7 +43,7 @@ export const isFreighterInstalled = () => {
  */
 export const connectWallet = async () => {
   try {
-    console.log('Connecting to Freighter wallet...');
+    logger.log('Connecting to Freighter wallet...');
 
     if (!isFreighterInstalled()) {
       throw new Error(
@@ -56,10 +57,10 @@ export const connectWallet = async () => {
       throw new Error('Invalid Stellar public key received from wallet');
     }
 
-    console.log('Wallet connected successfully. Public key:', publicKey);
+    logger.log('Wallet connected successfully. Public key:', publicKey);
     return publicKey;
   } catch (error) {
-    console.error('Error connecting wallet:', error.message);
+    logger.error('Error connecting wallet:', error.message);
     throw error;
   }
 };
@@ -111,7 +112,7 @@ export const signStellarTransaction = async (xdr, options = { network: 'TESTNET'
     const signedXDR = await signTransaction(xdr, options);
     return signedXDR;
   } catch (error) {
-    console.error('Error signing transaction:', error);
+    logger.error('Error signing transaction:', error);
     throw error;
   }
 };
@@ -171,7 +172,7 @@ export async function getTokenBalances(publicKey) {
 
     return balances;
   } catch (error) {
-    console.error('Error fetching token balances:', error);
+    logger.error('Error fetching token balances:', error);
     // Return zeros if account doesn't exist on network yet
     return { XLM: '0.0000', USDC: '0.0000' };
   }
@@ -204,7 +205,7 @@ export const getBalances = async (walletId, setBalances) => {
 
     setBalances(updatedBalances);
   } catch (error) {
-    console.error('Error fetching user balances:', error);
+    logger.error('Error fetching user balances:', error);
   }
 };
 
@@ -233,7 +234,7 @@ export const disconnectWallet = async () => {
     // 1. Alert the backend to delete the secure httpOnly cookie
     await axios.post('/api/auth/logout');
   } catch (error) {
-    console.error('Failed to cleanly terminate wallet session on backend:', error);
+    logger.error('Failed to cleanly terminate wallet session on backend:', error);
   } finally {
     // 2. Clear state elements out of application memory regardless of network success
     useWalletStore.getState().clearWallet();

--- a/quantara/frontend/src/services/walletconnect.js
+++ b/quantara/frontend/src/services/walletconnect.js
@@ -25,6 +25,7 @@ import QRCode from 'qrcode';
 
 import { axiosInstance } from '../utils/axios';
 import { STELLAR_NETWORK } from '../utils/constants';
+import { logger } from '@/utils/logger';
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — matches Redis TTL.
@@ -101,7 +102,7 @@ export const connectWallet = async ({ qrContainer, signal } = {}) => {
       }).catch((err) => {
         if (qrContainer) qrContainer.textContent = wcUri;
         // eslint-disable-next-line no-console
-        console.warn('WalletConnect QR render failed', err);
+        logger.warn('WalletConnect QR render failed', err);
       });
     }
 
@@ -134,7 +135,7 @@ export const connectWallet = async ({ qrContainer, signal } = {}) => {
         }
         if (err?.message?.includes('rejected') || err?.message?.includes('expired')) throw err;
         // eslint-disable-next-line no-console
-        console.debug('WalletConnect poll retry', err?.message);
+        logger.debug('WalletConnect poll retry', err?.message);
       }
     }
 
@@ -219,7 +220,7 @@ export const disconnectWallet = async () => {
       await axiosInstance.delete(`/api/walletconnect/session/${session.session_id}`);
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.warn('WalletConnect disconnect failed (best-effort)', err?.message);
+      logger.warn('WalletConnect disconnect failed (best-effort)', err?.message);
     }
   }
   sessionCache.session = null;

--- a/quantara/frontend/src/utils/axios.js
+++ b/quantara/frontend/src/utils/axios.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { logger } from '@/utils/logger';
 
 export const axiosInstance = axios.create({
   baseURL: process.env.VITE_APP_BACKEND_URL || 'http://localhost:8000',
@@ -13,14 +14,14 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response) {
-      console.error(
+      logger.error(
         `API error ${error.response.status}:`,
         error.response.data?.detail || error.message
       );
     } else if (error.request) {
-      console.error('Network error: no response received from server');
+      logger.error('Network error: no response received from server');
     } else {
-      console.error('Request configuration error:', error.message);
+      logger.error('Request configuration error:', error.message);
     }
     return Promise.reject(error);
   }

--- a/quantara/frontend/src/utils/logger.js
+++ b/quantara/frontend/src/utils/logger.js
@@ -1,0 +1,10 @@
+const write = (method, args) => {
+  if (import.meta.env.DEV) console[method](...args);
+};
+
+export const logger = {
+  debug: (...args) => write('debug', args),
+  error: (...args) => write('error', args),
+  log: (...args) => write('log', args),
+  warn: (...args) => write('warn', args),
+};

--- a/quantara/frontend/test/production-logging.test.js
+++ b/quantara/frontend/test/production-logging.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const srcRoot = path.resolve(__dirname, '../src');
+const allowedFiles = new Set([path.join(srcRoot, 'utils/logger.js')]);
+const sourceExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
+
+function listSourceFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listSourceFiles(fullPath);
+    if (!sourceExtensions.has(path.extname(entry.name))) return [];
+    return [fullPath];
+  });
+}
+
+describe('frontend production logging', () => {
+  it('routes production source logging through the dev-only logger', () => {
+    const offenders = listSourceFiles(srcRoot)
+      .filter((file) => !allowedFiles.has(file))
+      .filter((file) => fs.readFileSync(file, 'utf8').includes('console.'));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps logger output gated to development builds', () => {
+    const loggerSource = fs.readFileSync(path.join(srcRoot, 'utils/logger.js'), 'utf8');
+
+    expect(loggerSource).toContain('import.meta.env.DEV');
+    expect(loggerSource).not.toContain('console.log');
+  });
+});


### PR DESCRIPTION
Closes #264.

## Summary
- add a small `logger` wrapper that only writes in `import.meta.env.DEV`
- route existing frontend `console.log/error/warn/debug` calls through that wrapper
- add a Vitest static guard so production source files do not reintroduce raw `console.` calls

## Static validation performed
- Scanned `quantara/frontend/src/**/*.{js,jsx,ts,tsx}` on this branch and found zero raw `console.` references outside `src/utils/logger.js`.
- Confirmed the branch is 0 commits behind `main`.

## Testing
- Not run locally because this workspace is avoiding dependency installation and project toolchain execution.