### PR TITLE
Disable rate limiter memory fallback in production

### DIFF
--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -22,7 +22,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 import redis.asyncio as redis
 
-from web_app.api.rate_limiter import limiter
+from web_app.api.rate_limiter import assert_rate_limiter_backend_available, limiter
 from web_app.api.errors import APIError, api_error_handler
 from web_app.api.openapi import build_custom_openapi
 from web_app.api.dashboard import router as dashboard_router
@@ -89,6 +89,7 @@ async def lifespan(app: FastAPI):
 
     # Validate required environment variables at startup.
     assert_valid_config()
+    assert_rate_limiter_backend_available()
 
     # Enforce minimum length for session secret at startup
     secret = os.getenv("SESSION_SECRET_KEY")

--- a/quantara/web_app/api/rate_limiter.py
+++ b/quantara/web_app/api/rate_limiter.py
@@ -22,6 +22,8 @@ import asyncio
 import functools
 import os
 
+import redis
+
 from fastapi import Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -29,7 +31,31 @@ from slowapi.util import get_remote_address
 WRITE_LIMIT: str = os.getenv("RATE_LIMIT_WRITE", "5/minute")
 USER_DATA_LIMIT: str = os.getenv("RATE_LIMIT_USER_DATA", "30/minute")
 READ_LIMIT: str = os.getenv("RATE_LIMIT_READ", "100/minute")
+RATE_LIMIT_STORAGE_URI: str = os.getenv("REDIS_URL", "redis://localhost:6379")
 
+
+def is_production_env(env: str | None = None) -> bool:
+    return (env or os.getenv("ENV_VERSION", "DEV")).upper() == "PROD"
+
+
+def allow_in_memory_fallback(env: str | None = None) -> bool:
+    return not is_production_env(env)
+
+
+def assert_rate_limiter_backend_available(redis_url: str | None = None) -> None:
+    """Fail startup in production when Redis is unavailable for rate limiting."""
+    if not is_production_env():
+        return
+
+    client = redis.Redis.from_url(
+        redis_url or RATE_LIMIT_STORAGE_URI,
+        socket_connect_timeout=2,
+        socket_timeout=2,
+    )
+    try:
+        client.ping()
+    finally:
+        client.close()
 
 def get_wallet_key(request: Request) -> str:
     wallet_id = request.query_params.get("wallet_id") or request.path_params.get(
@@ -73,4 +99,7 @@ class LazyLimiter(Limiter):
         return decorator
 
 
-limiter = LazyLimiter()
+limiter = LazyLimiter(
+    storage_uri=RATE_LIMIT_STORAGE_URI,
+    in_memory_fallback_enabled=allow_in_memory_fallback(),
+)

--- a/quantara/web_app/api/rate_limiter.py
+++ b/quantara/web_app/api/rate_limiter.py
@@ -57,6 +57,7 @@ def assert_rate_limiter_backend_available(redis_url: str | None = None) -> None:
     finally:
         client.close()
 
+
 def get_wallet_key(request: Request) -> str:
     wallet_id = request.query_params.get("wallet_id") or request.path_params.get(
         "wallet_id"

--- a/quantara/web_app/tests/test_rate_limiter_prod_fallback.py
+++ b/quantara/web_app/tests/test_rate_limiter_prod_fallback.py
@@ -1,47 +1,66 @@
 import importlib
+import unittest
 from unittest.mock import MagicMock, patch
 
 
-def test_production_disables_in_memory_rate_limit_fallback():
-    with patch.dict("os.environ", {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"}):
-        import web_app.api.rate_limiter as rate_limiter
+class RateLimiterProductionFallbackTests(unittest.TestCase):
+    def test_production_disables_in_memory_rate_limit_fallback(self):
+        with patch.dict(
+            "os.environ",
+            {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"},
+        ):
+            import web_app.api.rate_limiter as rate_limiter
 
-        importlib.reload(rate_limiter)
+            importlib.reload(rate_limiter)
 
-        assert rate_limiter.allow_in_memory_fallback() is False
-        assert rate_limiter.limiter._in_memory_fallback_enabled is False
+            self.assertFalse(rate_limiter.allow_in_memory_fallback())
+            self.assertFalse(rate_limiter.limiter._in_memory_fallback_enabled)
+
+    def test_development_keeps_in_memory_rate_limit_fallback(self):
+        with patch.dict(
+            "os.environ",
+            {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"},
+        ):
+            import web_app.api.rate_limiter as rate_limiter
+
+            importlib.reload(rate_limiter)
+
+            self.assertTrue(rate_limiter.allow_in_memory_fallback())
+            self.assertTrue(rate_limiter.limiter._in_memory_fallback_enabled)
+
+    def test_production_startup_pings_redis_backend(self):
+        with patch.dict(
+            "os.environ",
+            {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"},
+        ):
+            import web_app.api.rate_limiter as rate_limiter
+
+            importlib.reload(rate_limiter)
+            fake_client = MagicMock()
+            with patch.object(
+                rate_limiter.redis.Redis,
+                "from_url",
+                return_value=fake_client,
+            ) as from_url:
+                rate_limiter.assert_rate_limiter_backend_available()
+
+        from_url.assert_called_once()
+        fake_client.ping.assert_called_once()
+        fake_client.close.assert_called_once()
+
+    def test_development_startup_skips_redis_ping(self):
+        with patch.dict(
+            "os.environ",
+            {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"},
+        ):
+            import web_app.api.rate_limiter as rate_limiter
+
+            importlib.reload(rate_limiter)
+            with patch.object(rate_limiter.redis.Redis, "from_url") as from_url:
+                rate_limiter.assert_rate_limiter_backend_available()
+
+        from_url.assert_not_called()
 
 
-def test_development_keeps_in_memory_rate_limit_fallback():
-    with patch.dict("os.environ", {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"}):
-        import web_app.api.rate_limiter as rate_limiter
-
-        importlib.reload(rate_limiter)
-
-        assert rate_limiter.allow_in_memory_fallback() is True
-        assert rate_limiter.limiter._in_memory_fallback_enabled is True
-
-
-def test_production_startup_pings_redis_backend():
-    with patch.dict("os.environ", {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"}):
-        import web_app.api.rate_limiter as rate_limiter
-
-        importlib.reload(rate_limiter)
-        fake_client = MagicMock()
-        with patch.object(rate_limiter.redis.Redis, "from_url", return_value=fake_client) as from_url:
-            rate_limiter.assert_rate_limiter_backend_available()
-
-    from_url.assert_called_once()
-    fake_client.ping.assert_called_once()
-    fake_client.close.assert_called_once()
-
-
-def test_development_startup_skips_redis_ping():
-    with patch.dict("os.environ", {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"}):
-        import web_app.api.rate_limiter as rate_limiter
-
-        importlib.reload(rate_limiter)
-        with patch.object(rate_limiter.redis.Redis, "from_url") as from_url:
-            rate_limiter.assert_rate_limiter_backend_available()
-
-    from_url.assert_not_called()
+if __name__ == "__main__":
+    unittest.main()

--- a/quantara/web_app/tests/test_rate_limiter_prod_fallback.py
+++ b/quantara/web_app/tests/test_rate_limiter_prod_fallback.py
@@ -1,0 +1,47 @@
+import importlib
+from unittest.mock import MagicMock, patch
+
+
+def test_production_disables_in_memory_rate_limit_fallback():
+    with patch.dict("os.environ", {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"}):
+        import web_app.api.rate_limiter as rate_limiter
+
+        importlib.reload(rate_limiter)
+
+        assert rate_limiter.allow_in_memory_fallback() is False
+        assert rate_limiter.limiter._in_memory_fallback_enabled is False
+
+
+def test_development_keeps_in_memory_rate_limit_fallback():
+    with patch.dict("os.environ", {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"}):
+        import web_app.api.rate_limiter as rate_limiter
+
+        importlib.reload(rate_limiter)
+
+        assert rate_limiter.allow_in_memory_fallback() is True
+        assert rate_limiter.limiter._in_memory_fallback_enabled is True
+
+
+def test_production_startup_pings_redis_backend():
+    with patch.dict("os.environ", {"ENV_VERSION": "PROD", "REDIS_URL": "redis://redis:6379"}):
+        import web_app.api.rate_limiter as rate_limiter
+
+        importlib.reload(rate_limiter)
+        fake_client = MagicMock()
+        with patch.object(rate_limiter.redis.Redis, "from_url", return_value=fake_client) as from_url:
+            rate_limiter.assert_rate_limiter_backend_available()
+
+    from_url.assert_called_once()
+    fake_client.ping.assert_called_once()
+    fake_client.close.assert_called_once()
+
+
+def test_development_startup_skips_redis_ping():
+    with patch.dict("os.environ", {"ENV_VERSION": "DEV", "REDIS_URL": "redis://127.0.0.1:1"}):
+        import web_app.api.rate_limiter as rate_limiter
+
+        importlib.reload(rate_limiter)
+        with patch.object(rate_limiter.redis.Redis, "from_url") as from_url:
+            rate_limiter.assert_rate_limiter_backend_available()
+
+    from_url.assert_not_called()


### PR DESCRIPTION
Closes #194.

## Summary
- configure the module-level SlowAPI limiter with the Redis storage URI instead of leaving storage implicit
- disable `in_memory_fallback_enabled` when `ENV_VERSION=PROD`, while preserving the fallback in development
- fail production startup by pinging Redis during FastAPI lifespan before serving requests
- add regression coverage for PROD/DEV fallback policy and startup Redis ping behavior

## Validation
- Parsed the changed Python files with `ast.parse` using the bundled Codex Python runtime.
- GitHub compare reports this branch is 0 commits behind `main`.

## Testing
- Not run as a full local project suite because this workspace is avoiding dependency installation and project toolchain execution.