### PR TITLE
Run health alert checks concurrently

### DIFF
--- a/quantara/web_app/contract_tools/mixins/alert.py
+++ b/quantara/web_app/contract_tools/mixins/alert.py
@@ -2,8 +2,11 @@
 This module contains the alert mixin class for health ratio monitoring.
 """
 
+import asyncio
 import logging
 import os
+
+from prometheus_client import Counter
 
 from web_app.telegram.notifications import send_health_ratio_notification
 from web_app.contract_tools.mixins.health_ratio import HealthRatioMixin
@@ -13,6 +16,13 @@ from web_app.api.dependencies import get_stellar_client
 
 logger = logging.getLogger(__name__)
 ALERT_THRESHOLD = float(os.getenv("HEALTH_RATIO_ALERT_THRESHOLD", "1.1"))
+ALERT_BATCH_CONCURRENCY = int(os.getenv("HEALTH_ALERT_BATCH_CONCURRENCY", "16"))
+ALERT_USER_TIMEOUT_SECONDS = float(os.getenv("HEALTH_ALERT_USER_TIMEOUT_SECONDS", "10"))
+HEALTH_ALERT_SWEEP_RESULTS = Counter(
+    "health_alert_sweep_results_total",
+    "Health-ratio alert sweep outcomes by user check result.",
+    ["result"],
+)
 
 
 class AlertMixin:
@@ -20,6 +30,39 @@ class AlertMixin:
     Mixin class for alert related methods.
     Handles health ratio monitoring and notification dispatch.
     """
+
+    @classmethod
+    async def _check_single_user_health_ratio(
+        cls,
+        contract_address: str,
+        telegram_id: int,
+        client,
+    ) -> bool:
+        if not contract_address:
+            HEALTH_ALERT_SWEEP_RESULTS.labels(result="failure").inc()
+            return False
+
+        try:
+            health_ratio_level, _ = await asyncio.wait_for(
+                HealthRatioMixin.get_health_ratio_and_tvl(contract_address, client),
+                timeout=ALERT_USER_TIMEOUT_SECONDS,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to get health ratio for %s: %s", contract_address, e
+            )
+            HEALTH_ALERT_SWEEP_RESULTS.labels(result="failure").inc()
+            return False
+
+        health_value = float(health_ratio_level)
+        if health_value < ALERT_THRESHOLD:
+            logger.info(
+                f"Health ratio level for user {contract_address} is {health_ratio_level}"
+            )
+            await cls.send_notification(telegram_id, health_ratio_level)
+
+        HEALTH_ALERT_SWEEP_RESULTS.labels(result="success").inc()
+        return True
 
     @classmethod
     async def check_users_health_ratio_level(cls) -> None:
@@ -33,24 +76,27 @@ class AlertMixin:
         client = get_stellar_client()
         user_number = len([user for user, _ in users_data])
         logger.info(f"Found number of users for notifications: {user_number}")
-        for contract_address, telegram_id in users_data:
-            if not contract_address:
-                continue
-            try:
-                health_ratio_level, _ = \
-                    await HealthRatioMixin.get_health_ratio_and_tvl(contract_address, client)
-            except Exception as e:
-                logger.error(
-                    "Failed to get health ratio for %s: %s", contract_address, e
-                )
-                continue
 
-            health_value = float(health_ratio_level)
-            if health_value < ALERT_THRESHOLD:
-                logger.info(
-                    f"Health ratio level for user {contract_address} is {health_ratio_level}"
+        semaphore = asyncio.Semaphore(ALERT_BATCH_CONCURRENCY)
+
+        async def check_with_limit(contract_address: str, telegram_id: int) -> bool:
+            async with semaphore:
+                return await cls._check_single_user_health_ratio(
+                    contract_address,
+                    telegram_id,
+                    client,
                 )
-                await cls.send_notification(telegram_id, health_ratio_level)
+
+        results = await asyncio.gather(
+            *(check_with_limit(contract_address, telegram_id) for contract_address, telegram_id in users_data),
+            return_exceptions=True,
+        )
+        successes = sum(result is True for result in results)
+        failures = len(results) - successes
+        logger.info(
+            "health_ratio_alert_sweep_complete",
+            extra={"success": successes, "failure": failures},
+        )
 
     @staticmethod
     async def send_notification(telegram_id: int, health_ratio: float):

--- a/quantara/web_app/contract_tools/mixins/alert.py
+++ b/quantara/web_app/contract_tools/mixins/alert.py
@@ -57,7 +57,9 @@ class AlertMixin:
         health_value = float(health_ratio_level)
         if health_value < ALERT_THRESHOLD:
             logger.info(
-                f"Health ratio level for user {contract_address} is {health_ratio_level}"
+                "Health ratio level for user %s is %s",
+                contract_address,
+                health_ratio_level,
             )
             await cls.send_notification(telegram_id, health_ratio_level)
 
@@ -88,7 +90,10 @@ class AlertMixin:
                 )
 
         results = await asyncio.gather(
-            *(check_with_limit(contract_address, telegram_id) for contract_address, telegram_id in users_data),
+            *(
+                check_with_limit(contract_address, telegram_id)
+                for contract_address, telegram_id in users_data
+            ),
             return_exceptions=True,
         )
         successes = sum(result is True for result in results)

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -1,0 +1,75 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from web_app.contract_tools.mixins.alert import AlertMixin
+
+
+@pytest.mark.asyncio
+async def test_alert_sweep_continues_after_user_failure():
+    users = [("contract-ok", 1001), ("contract-fail", 1002), ("contract-low", 1003)]
+
+    async def fake_health_ratio(contract_address, client):
+        if contract_address == "contract-fail":
+            raise RuntimeError("rpc failed")
+        if contract_address == "contract-low":
+            return "1.0", "100"
+        return "1.5", "100"
+
+    with patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
+         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
+         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
+         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock) as send_notification:
+        connector.return_value.get_users_for_notifications.return_value = users
+
+        await AlertMixin.check_users_health_ratio_level()
+
+    send_notification.assert_awaited_once_with(1003, "1.0")
+
+
+@pytest.mark.asyncio
+async def test_alert_sweep_runs_health_checks_concurrently():
+    users = [(f"contract-{idx}", idx) for idx in range(4)]
+    started = 0
+    peak_started = 0
+    release = asyncio.Event()
+
+    async def fake_health_ratio(contract_address, client):
+        nonlocal started, peak_started
+        started += 1
+        peak_started = max(peak_started, started)
+        if started == len(users):
+            release.set()
+        await release.wait()
+        return "1.5", "100"
+
+    with patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users)), \
+         patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
+         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
+         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
+         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock):
+        connector.return_value.get_users_for_notifications.return_value = users
+
+        await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)
+
+    assert peak_started == len(users)
+
+
+@pytest.mark.asyncio
+async def test_single_user_timeout_does_not_stop_successes():
+    users = [("contract-timeout", 1001), ("contract-ok", 1002)]
+
+    async def fake_health_ratio(contract_address, client):
+        if contract_address == "contract-timeout":
+            await asyncio.sleep(1)
+        return "1.5", "100"
+
+    with patch("web_app.contract_tools.mixins.alert.ALERT_USER_TIMEOUT_SECONDS", 0.01), \
+         patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
+         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
+         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
+         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock):
+        connector.return_value.get_users_for_notifications.return_value = users
+
+        await AlertMixin.check_users_health_ratio_level()

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import ExitStack
+from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -72,7 +73,7 @@ async def test_alert_sweep_runs_health_checks_concurrently():
 
         await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)
 
-    assert peak_started == len(users)
+    TestCase().assertEqual(peak_started, len(users))
 
 
 @pytest.mark.asyncio

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -6,6 +6,10 @@ import pytest
 
 from web_app.contract_tools.mixins.alert import AlertMixin
 
+USER_CONNECTOR = "web_app.contract_tools.mixins.alert.UserDBConnector"
+STELLAR_CLIENT = "web_app.contract_tools.mixins.alert.get_stellar_client"
+HEALTH_RATIO = "web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl"
+
 
 @pytest.mark.asyncio
 async def test_alert_sweep_continues_after_user_failure():
@@ -18,7 +22,17 @@ async def test_alert_sweep_continues_after_user_failure():
             return "1.0", "100"
         return "1.5", "100"
 
-    with ExitStack() as stack:`n        connector = stack.enter_context(patch("web_app.contract_tools.mixins.alert.UserDBConnector"))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio))`n        send_notification = stack.enter_context(patch.object(AlertMixin, "send_notification", new_callable=AsyncMock))`n        connector.return_value.get_users_for_notifications.return_value = users`n`n        await AlertMixin.check_users_health_ratio_level()`n
+    with ExitStack() as stack:
+        connector = stack.enter_context(patch(USER_CONNECTOR))
+        stack.enter_context(patch(STELLAR_CLIENT, return_value=MagicMock()))
+        stack.enter_context(patch(HEALTH_RATIO, side_effect=fake_health_ratio))
+        send_notification = stack.enter_context(
+            patch.object(AlertMixin, "send_notification", new_callable=AsyncMock)
+        )
+        connector.return_value.get_users_for_notifications.return_value = users
+
+        await AlertMixin.check_users_health_ratio_level()
+
     send_notification.assert_awaited_once_with(1003, "1.0")
 
 
@@ -38,7 +52,20 @@ async def test_alert_sweep_runs_health_checks_concurrently():
         await release.wait()
         return "1.5", "100"
 
-    with ExitStack() as stack:`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users)))`n        connector = stack.enter_context(patch("web_app.contract_tools.mixins.alert.UserDBConnector"))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio))`n        stack.enter_context(patch.object(AlertMixin, "send_notification", new_callable=AsyncMock))`n        connector.return_value.get_users_for_notifications.return_value = users`n`n        await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)`n
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users))
+        )
+        connector = stack.enter_context(patch(USER_CONNECTOR))
+        stack.enter_context(patch(STELLAR_CLIENT, return_value=MagicMock()))
+        stack.enter_context(patch(HEALTH_RATIO, side_effect=fake_health_ratio))
+        stack.enter_context(
+            patch.object(AlertMixin, "send_notification", new_callable=AsyncMock)
+        )
+        connector.return_value.get_users_for_notifications.return_value = users
+
+        await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)
+
     assert peak_started == len(users)
 
 
@@ -51,11 +78,16 @@ async def test_single_user_timeout_does_not_stop_successes():
             await asyncio.sleep(1)
         return "1.5", "100"
 
-    with patch("web_app.contract_tools.mixins.alert.ALERT_USER_TIMEOUT_SECONDS", 0.01), \
-         patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
-         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
-         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
-         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock):
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("web_app.contract_tools.mixins.alert.ALERT_USER_TIMEOUT_SECONDS", 0.01)
+        )
+        connector = stack.enter_context(patch(USER_CONNECTOR))
+        stack.enter_context(patch(STELLAR_CLIENT, return_value=MagicMock()))
+        stack.enter_context(patch(HEALTH_RATIO, side_effect=fake_health_ratio))
+        stack.enter_context(
+            patch.object(AlertMixin, "send_notification", new_callable=AsyncMock)
+        )
         connector.return_value.get_users_for_notifications.return_value = users
 
         await AlertMixin.check_users_health_ratio_level()

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,14 +18,7 @@ async def test_alert_sweep_continues_after_user_failure():
             return "1.0", "100"
         return "1.5", "100"
 
-    with patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
-         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
-         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
-         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock) as send_notification:
-        connector.return_value.get_users_for_notifications.return_value = users
-
-        await AlertMixin.check_users_health_ratio_level()
-
+    with ExitStack() as stack:`n        connector = stack.enter_context(patch("web_app.contract_tools.mixins.alert.UserDBConnector"))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio))`n        send_notification = stack.enter_context(patch.object(AlertMixin, "send_notification", new_callable=AsyncMock))`n        connector.return_value.get_users_for_notifications.return_value = users`n`n        await AlertMixin.check_users_health_ratio_level()`n
     send_notification.assert_awaited_once_with(1003, "1.0")
 
 
@@ -44,15 +38,7 @@ async def test_alert_sweep_runs_health_checks_concurrently():
         await release.wait()
         return "1.5", "100"
 
-    with patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users)), \
-         patch("web_app.contract_tools.mixins.alert.UserDBConnector") as connector, \
-         patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()), \
-         patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio), \
-         patch.object(AlertMixin, "send_notification", new_callable=AsyncMock):
-        connector.return_value.get_users_for_notifications.return_value = users
-
-        await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)
-
+    with ExitStack() as stack:`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users)))`n        connector = stack.enter_context(patch("web_app.contract_tools.mixins.alert.UserDBConnector"))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.get_stellar_client", return_value=MagicMock()))`n        stack.enter_context(patch("web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl", side_effect=fake_health_ratio))`n        stack.enter_context(patch.object(AlertMixin, "send_notification", new_callable=AsyncMock))`n        connector.return_value.get_users_for_notifications.return_value = users`n`n        await asyncio.wait_for(AlertMixin.check_users_health_ratio_level(), timeout=1)`n
     assert peak_started == len(users)
 
 

--- a/quantara/web_app/tests/test_alert_mixin.py
+++ b/quantara/web_app/tests/test_alert_mixin.py
@@ -8,7 +8,10 @@ from web_app.contract_tools.mixins.alert import AlertMixin
 
 USER_CONNECTOR = "web_app.contract_tools.mixins.alert.UserDBConnector"
 STELLAR_CLIENT = "web_app.contract_tools.mixins.alert.get_stellar_client"
-HEALTH_RATIO = "web_app.contract_tools.mixins.alert.HealthRatioMixin.get_health_ratio_and_tvl"
+HEALTH_RATIO = (
+    "web_app.contract_tools.mixins.alert."
+    "HealthRatioMixin.get_health_ratio_and_tvl"
+)
 
 
 @pytest.mark.asyncio
@@ -54,7 +57,10 @@ async def test_alert_sweep_runs_health_checks_concurrently():
 
     with ExitStack() as stack:
         stack.enter_context(
-            patch("web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY", len(users))
+            patch(
+                "web_app.contract_tools.mixins.alert.ALERT_BATCH_CONCURRENCY",
+                len(users),
+            )
         )
         connector = stack.enter_context(patch(USER_CONNECTOR))
         stack.enter_context(patch(STELLAR_CLIENT, return_value=MagicMock()))
@@ -80,7 +86,10 @@ async def test_single_user_timeout_does_not_stop_successes():
 
     with ExitStack() as stack:
         stack.enter_context(
-            patch("web_app.contract_tools.mixins.alert.ALERT_USER_TIMEOUT_SECONDS", 0.01)
+            patch(
+                "web_app.contract_tools.mixins.alert.ALERT_USER_TIMEOUT_SECONDS",
+                0.01,
+            )
         )
         connector = stack.enter_context(patch(USER_CONNECTOR))
         stack.enter_context(patch(STELLAR_CLIENT, return_value=MagicMock()))


### PR DESCRIPTION
Closes #206.

## Summary
- check notification users concurrently with a configurable semaphore cap
- apply a per-user timeout so one slow RPC does not block the alert sweep
- record Prometheus success/failure counters for mixed alert sweep outcomes
- add async tests for failure isolation, concurrency, and timeout continuation

## Validation
- Parsed the changed Python files with `ast.parse` using the bundled Codex Python runtime.
- Checked changed lines stay within the project lint line-length convention.
- GitHub compare reports this branch is 0 commits behind `main`.

## Testing
- Not run as a full local project suite because this workspace is avoiding dependency installation and project toolchain execution.