### PR TITLE
Migrate position mutations to POST

### DIFF
--- a/quantara/frontend/src/hooks/useClosePosition.js
+++ b/quantara/frontend/src/hooks/useClosePosition.js
@@ -28,10 +28,13 @@ export const useClosePosition = () => {
       });
       const transactionResult = await closePosition(response.data);
       console.log('TransactionResult', transactionResult);
-      await axiosInstance.get('/api/close-position', {
+      await axiosInstance.post('/api/close-position', null, {
         params: {
           position_id: response.data.position_id,
           transaction_hash: transactionResult.transaction_hash,
+        },
+        headers: {
+          'Idempotency-Key': `close:${response.data.position_id}:${transactionResult.transaction_hash}`,
         },
       });
     },

--- a/quantara/frontend/src/hooks/useWithdrawAll.js
+++ b/quantara/frontend/src/hooks/useWithdrawAll.js
@@ -21,8 +21,11 @@ const useWithdrawAll = () => {
         withdraw_data.repay_data.contract_address
       );
 
-      await axiosInstance.get('/api/close-position', {
+      await axiosInstance.post('/api/close-position', null, {
         params: { transaction_hash: transaction_hash, position_id: withdraw_data.repay_data.position_id },
+        headers: {
+          'Idempotency-Key': `close:${withdraw_data.repay_data.position_id}:${transaction_hash}`,
+        },
       });
     },
     onSuccess: () => {

--- a/quantara/frontend/src/services/transaction.js
+++ b/quantara/frontend/src/services/transaction.js
@@ -276,10 +276,13 @@ export const handleTransaction = async (connectedWalletId, formData, setTokenAmo
     );
 
     // Notify backend of position creation with real transaction hash
-    await axiosInstance.get(`/api/open-position`, {
+    await axiosInstance.post(`/api/open-position`, null, {
       params: {
         position_id: transactionData.position_id,
         transaction_hash,
+      },
+      headers: {
+        'Idempotency-Key': `open:${transactionData.position_id}:${transaction_hash}`,
       },
     });
 

--- a/quantara/frontend/test/services/transaction.test.js
+++ b/quantara/frontend/test/services/transaction.test.js
@@ -106,18 +106,15 @@ describe('Transaction Functions', () => {
     });
 
     it('should handle successful transaction flow', async () => {
-      axiosInstance.get.mockResolvedValueOnce({
-        data: { status: 'open' },
-      });
-
       await handleTransaction(mockWalletId, mockFormData, mockSetTokenAmount, mockSetLoading);
 
       expect(mockSetLoading).toHaveBeenCalledWith(true);
       expect(getWalletPublicKey).toHaveBeenCalled();
       expect(axiosInstance.post).toHaveBeenCalledWith('/api/create-position', mockFormData, { headers: { 'x-wallet-id': 'mock', 'x-nonce': 'mock', 'x-signature': 'mock' } });
       expect(invokeSorobanContract).toHaveBeenCalled();
-      expect(axiosInstance.get).toHaveBeenCalledWith('/api/open-position', {
+      expect(axiosInstance.post).toHaveBeenCalledWith('/api/open-position', null, {
         params: { position_id: 1, transaction_hash: mockTransactionHash },
+        headers: { 'Idempotency-Key': `open:1:${mockTransactionHash}` },
       });
       expect(mockSetTokenAmount).toHaveBeenCalledWith('');
       expect(mockSetLoading).toHaveBeenCalledWith(false);

--- a/quantara/web_app/api/main.py
+++ b/quantara/web_app/api/main.py
@@ -38,7 +38,7 @@ from web_app.api.pausable import protocol_pause_middleware
 from web_app.api.pausable import router as pausable_router
 from web_app.api.walletconnect import router as walletconnect_router
 from web_app.config_validator import assert_valid_config
-from web_app.api.middleware import AccessLogMiddleware, MaxBodySizeMiddleware, SecurityHeadersMiddleware
+from web_app.api.middleware import AccessLogMiddleware, IdempotencyKeyMiddleware, MaxBodySizeMiddleware, SecurityHeadersMiddleware
 from web_app.db.database import init_db
 from web_app.db.database import init_db, get_database
 from web_app.utils.logger import configure_logging, get_logger
@@ -48,7 +48,7 @@ configure_logging()
 logger = get_logger(__name__)
 DEFAULT_CORS_ORIGINS = ["http://localhost:3000"]
 CORS_ALLOW_METHODS = ["GET", "POST"]
-CORS_ALLOW_HEADERS = ["Content-Type", "Authorization", "X-Wallet-Id", "X-Nonce", "X-Signature"]
+CORS_ALLOW_HEADERS = ["Content-Type", "Authorization", "X-Wallet-Id", "X-Nonce", "X-Signature", "Idempotency-Key"]
 
 
 def get_cors_origins() -> list[str]:
@@ -171,6 +171,7 @@ app.add_middleware(
 # Rate limiting middleware -- must be added after CORS/session so it wraps the
 # full middleware stack and can reject requests before they reach routers.
 app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(IdempotencyKeyMiddleware)
 app.add_middleware(MaxBodySizeMiddleware, max_body_size=1024*1024)
 app.add_middleware(PrometheusMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)

--- a/quantara/web_app/api/middleware.py
+++ b/quantara/web_app/api/middleware.py
@@ -12,6 +12,59 @@ from starlette.responses import Response
 logger = structlog.get_logger(__name__)
 
 
+class IdempotencyKeyMiddleware:
+    """Cache POST responses when clients retry with the same Idempotency-Key."""
+
+    def __init__(self, app):
+        self.app = app
+        self._responses = {}
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+
+        idempotency_key = None
+        for name, value in scope.get("headers", []):
+            if name.lower() == b"idempotency-key":
+                idempotency_key = value.decode("utf-8")
+                break
+
+        if not idempotency_key:
+            await self.app(scope, receive, send)
+            return
+
+        cache_key = (
+            scope.get("method"),
+            scope.get("path"),
+            scope.get("query_string", b""),
+            idempotency_key,
+        )
+        cached_response = self._responses.get(cache_key)
+        if cached_response:
+            start_message, body_messages = cached_response
+            await send(dict(start_message))
+            for message in body_messages:
+                await send(dict(message))
+            return
+
+        captured_start = None
+        captured_body = []
+
+        async def capture_send(message):
+            nonlocal captured_start
+            if message["type"] == "http.response.start":
+                captured_start = dict(message)
+            elif message["type"] == "http.response.body":
+                captured_body.append(dict(message))
+            await send(message)
+
+        await self.app(scope, receive, capture_send)
+
+        if captured_start and 200 <= captured_start.get("status", 500) < 300:
+            self._responses[cache_key] = (captured_start, captured_body)
+
+
 class AccessLogMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         structlog.contextvars.clear_contextvars()

--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -149,7 +149,7 @@ async def get_repay_data(
     return repay_data
 
 
-@router.get(
+@router.post(
     "/api/close-position",
     tags=["Position Operations"],
     response_model=str,
@@ -177,7 +177,7 @@ async def close_position(request: Request, position_id: UUID, transaction_hash: 
     return position_status
 
 
-@router.get(
+@router.post(
     "/api/open-position",
     tags=["Position Operations"],
     response_model=str,

--- a/quantara/web_app/tests/test_outbox.py
+++ b/quantara/web_app/tests/test_outbox.py
@@ -30,8 +30,9 @@ async def test_open_position_queues_outbox_event(client: TestClient) -> None:
     with patch("web_app.api.position.PositionDBConnector.get_object", return_value=mock_position) as mock_get, \
          patch("web_app.api.position.PositionDBConnector.write_to_db", side_effect=mock_write) as mock_write_db:
         
-        response = client.get(
-            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}"
+        response = client.post(
+            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}",
+            headers={"Idempotency-Key": f"open:{position_id}:{transaction_hash}"},
         )
         assert response.status_code == 200
         assert response.json() == "pending"

--- a/quantara/web_app/tests/test_positions.py
+++ b/quantara/web_app/tests/test_positions.py
@@ -38,8 +38,9 @@ async def test_open_position_success(client: TestClient) -> None:
     ) as mock_get, patch(
         "web_app.api.position.PositionDBConnector.write_to_db", return_value=None
     ) as mock_write:
-        response = client.get(
-            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}"
+        response = client.post(
+            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}",
+            headers={"Idempotency-Key": f"open:{position_id}:{transaction_hash}"},
         )
         assert response.is_success
         assert response.json() == "pending"
@@ -56,9 +57,56 @@ async def test_open_position_missing_position_data(
     Returns:
         None
     """
-    response = client.get("/api/open-position?position_id=&transaction_hash=")
+    response = client.post("/api/open-position?position_id=&transaction_hash=")
     assert response.status_code == 404
     assert response.json() == {"detail": "Position not found"}
+
+
+@pytest.mark.anyio
+async def test_open_position_get_not_allowed(client: TestClient) -> None:
+    """
+    Opening a position is a mutation and should not be reachable via GET.
+    """
+    position_id = str(uuid.uuid4())
+    response = client.get(
+        f"/api/open-position?position_id={position_id}&transaction_hash=valid_transaction_hash"
+    )
+    assert response.status_code == 405
+
+
+@pytest.mark.anyio
+async def test_open_position_idempotency_key_replays_cached_response(
+    client: TestClient,
+) -> None:
+    """
+    Replaying the same POST with the same Idempotency-Key should not double write.
+    """
+    position_id = str(uuid.uuid4())
+    transaction_hash = "valid_transaction_hash"
+    mock_position = Mock(spec=Position)
+    mock_position.id = uuid.UUID(position_id)
+    mock_position.status = "pending"
+    headers = {"Idempotency-Key": f"open:{position_id}:{transaction_hash}"}
+
+    with patch(
+        "web_app.api.position.PositionDBConnector.get_object", return_value=mock_position
+    ), patch(
+        "web_app.api.position.PositionDBConnector.write_to_db", return_value=None
+    ) as mock_write:
+        first_response = client.post(
+            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}",
+            headers=headers,
+        )
+        second_response = client.post(
+            f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}",
+            headers=headers,
+        )
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+        assert first_response.json() == "pending"
+        assert second_response.json() == "pending"
+        assert mock_write.call_count == 1
 
 
 @pytest.mark.anyio
@@ -77,8 +125,9 @@ async def test_close_position_success(client: TestClient) -> None:
     ) as mock_close_position:
         mock_close_position.return_value = "Position successfully closed"
 
-        response = client.get(
-            f"/api/close-position?position_id={position_id}&transaction_hash={transaction_hash}"
+        response = client.post(
+            f"/api/close-position?position_id={position_id}&transaction_hash={transaction_hash}",
+            headers={"Idempotency-Key": f"close:{position_id}:{transaction_hash}"},
         )
 
         assert response.status_code == 200
@@ -102,7 +151,7 @@ async def test_close_position_invalid_position_id(client: TestClient) -> None:
         mock_close_position.side_effect = HTTPException(
             status_code=404, detail="Position not Found"
         )
-        response = client.get(
+        response = client.post(
             f"/api/close-position?position_id={invalid_position_id}&transaction_hash=0xabc123"
         )
         assert response.status_code == 404

--- a/quantara/web_app/tests/test_positions.py
+++ b/quantara/web_app/tests/test_positions.py
@@ -9,6 +9,7 @@ that all edge cases and error scenarios are appropriately handled.
 
 import uuid
 from datetime import datetime
+from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import pytest
@@ -42,8 +43,8 @@ async def test_open_position_success(client: TestClient) -> None:
             f"/api/open-position?position_id={position_id}&transaction_hash={transaction_hash}",
             headers={"Idempotency-Key": f"open:{position_id}:{transaction_hash}"},
         )
-        assert response.is_success
-        assert response.json() == "pending"
+        TestCase().assertTrue(response.is_success)
+        TestCase().assertEqual(response.json(), "pending")
 
 
 @pytest.mark.anyio
@@ -102,11 +103,12 @@ async def test_open_position_idempotency_key_replays_cached_response(
             headers=headers,
         )
 
-        assert first_response.status_code == 200
-        assert second_response.status_code == 200
-        assert first_response.json() == "pending"
-        assert second_response.json() == "pending"
-        assert mock_write.call_count == 1
+        test_case = TestCase()
+        test_case.assertEqual(first_response.status_code, 200)
+        test_case.assertEqual(second_response.status_code, 200)
+        test_case.assertEqual(first_response.json(), "pending")
+        test_case.assertEqual(second_response.json(), "pending")
+        test_case.assertEqual(mock_write.call_count, 1)
 
 
 @pytest.mark.anyio

--- a/quantara/web_app/tests/test_positions.py
+++ b/quantara/web_app/tests/test_positions.py
@@ -72,7 +72,7 @@ async def test_open_position_get_not_allowed(client: TestClient) -> None:
     response = client.get(
         f"/api/open-position?position_id={position_id}&transaction_hash=valid_transaction_hash"
     )
-    assert response.status_code == 405
+    TestCase().assertEqual(response.status_code, 405)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #216.

Changes:
- moves `/api/open-position` and `/api/close-position` from GET to POST
- adds `IdempotencyKeyMiddleware` and allows the `Idempotency-Key` CORS header
- sends stable idempotency keys from the frontend mutation calls
- updates position/outbox/frontend tests for POST and replay behavior

Validation:
- parsed changed Python files with `ast.parse`
- did not run the full project test suite locally because that would require installing/executing project dependencies in this environment