### PR TITLE
Cache get_stats with SQL USDC aggregate

### DIFF
--- a/quantara/web_app/api/position.py
+++ b/quantara/web_app/api/position.py
@@ -25,6 +25,7 @@ from web_app.contract_tools.mixins import DashboardMixin, DepositMixin, Position
 from web_app.db.crud import PositionDBConnector, TransactionDBConnector
 from web_app.api.dependencies import get_stellar_client
 from web_app.contract_tools.blockchain_call import StellarClient
+from web_app.contract_tools.cache import delete_cache_key
 from web_app.db.models import Status, TransactionStatus
 from web_app.api.rate_limiter import limiter, WRITE_LIMIT, USER_DATA_LIMIT, READ_LIMIT
 from web_app.utils.logger import get_logger
@@ -35,6 +36,7 @@ position_db_connector = PositionDBConnector()
 transaction_db_connector = TransactionDBConnector()
 
 PAGINATION_STEP = 10
+GET_STATS_CACHE_KEY = "stats:get_stats:v1"
 
 
 @router.get(
@@ -171,6 +173,7 @@ async def close_position(request: Request, position_id: UUID, transaction_hash: 
         raise HTTPException(status_code=400, detail="Transaction hash is required")
 
     position_status = position_db_connector.close_position(str(position_id))
+    await delete_cache_key(GET_STATS_CACHE_KEY)
     position_db_connector.save_transaction(
         position_id=position_id, status="closed", transaction_hash=transaction_hash
     )

--- a/quantara/web_app/api/user.py
+++ b/quantara/web_app/api/user.py
@@ -3,7 +3,6 @@ This module handles user-related API endpoints.
 """
 
 import logging
-from decimal import Decimal
 
 import sentry_sdk
 from fastapi import APIRouter, HTTPException, Depends, Request
@@ -20,6 +19,7 @@ from web_app.api.serializers.user import (
 )
 from web_app.api.dependencies import get_stellar_client, verify_wallet_signature
 from web_app.contract_tools.blockchain_call import StellarClient
+from web_app.contract_tools.cache import get_cached_or_fetch
 from web_app.contract_tools.mixins import DashboardMixin, PositionMixin
 from web_app.db.crud import (
     PositionDBConnector,
@@ -36,6 +36,8 @@ telegram_db = TelegramUserDBConnector()
 
 user_db = UserDBConnector()
 position_db = PositionDBConnector()
+GET_STATS_CACHE_KEY = "stats:get_stats:v1"
+GET_STATS_CACHE_TTL_SECONDS = 10
 
 
 @router.get(
@@ -245,37 +247,23 @@ async def get_stats(request: Request) -> GetStatsResponse:
     - unique_users: Total count of unique users.
     """
     try:
-        # Fetch open positions amounts by token
-        token_amounts = position_db.get_total_amounts_for_open_positions()
+        async def fetch_stats() -> dict:
+            current_prices = await DashboardMixin.get_current_prices()
+            total_opened_amount = position_db.get_total_opened_amount_usdc(
+                current_prices
+            )
+            unique_users = user_db.get_unique_users_count()
+            return {
+                "total_opened_amount": str(total_opened_amount),
+                "unique_users": unique_users,
+            }
 
-        # Fetch current prices
-        current_prices = await DashboardMixin.get_current_prices()
-
-        # Convert all token amounts to USDC
-        total_opened_amount = Decimal("0")
-        for token, amount in token_amounts.items():
-            # Skip if no price available for the token
-            if token not in current_prices:
-                logger.warning("no_price_data", token=token)
-                continue
-
-            # If the token is USDC, use it directly
-            if token == "USDC":
-                total_opened_amount += amount
-                continue
-
-            # Convert other tokens to USDC
-            # Price is typically in USDC per token
-            usdc_price = current_prices.get(token)
-            if usdc_price is None:
-                continue
-            usdc_equivalent = amount * Decimal(str(usdc_price))
-            total_opened_amount += usdc_equivalent
-
-        unique_users = user_db.get_unique_users_count()
-        return GetStatsResponse(
-            total_opened_amount=total_opened_amount, unique_users=unique_users
+        stats = await get_cached_or_fetch(
+            GET_STATS_CACHE_KEY,
+            ttl=GET_STATS_CACHE_TTL_SECONDS,
+            fetch_fn=fetch_stats,
         )
+        return GetStatsResponse(**stats)
 
     except Exception as e:
         logger.error("get_stats_error", exc_info=True)

--- a/quantara/web_app/contract_tools/cache.py
+++ b/quantara/web_app/contract_tools/cache.py
@@ -52,3 +52,15 @@ async def get_cached_or_fetch(
         return value
     finally:
         await client.close()
+
+
+async def delete_cache_key(key: str) -> None:
+    """Best-effort deletion for lifecycle invalidation."""
+    pool = await get_redis_pool()
+    client = redis.Redis(connection_pool=pool)
+    try:
+        await client.delete(key)
+    except Exception as exc:
+        logger.warning("Cache delete failed for %s: %s", key, exc)
+    finally:
+        await client.close()

--- a/quantara/web_app/db/crud/position.py
+++ b/quantara/web_app/db/crud/position.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from typing import TypeVar
 from uuid import UUID
 
-from sqlalchemy import Numeric, cast, func
+from sqlalchemy import Numeric, cast, func, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -345,8 +345,56 @@ class PositionDBConnector(UserDBConnector):
                 return {token: Decimal(str(amount)) for token, amount in token_amounts}
 
             except SQLAlchemyError as e:
-                logger.error("db_calc_open_amounts_failed", error=str(e))
-                return {}
+                  logger.error("db_calc_open_amounts_failed", error=str(e))
+                  return {}
+
+    def get_total_opened_amount_usdc(self, current_prices: dict) -> Decimal:
+        """
+        Calculates the USDC value of opened positions in SQL.
+
+        :param current_prices: Dictionary of token symbol to USDC price
+        :return: Total opened position value in USDC
+        """
+        token_prices = {"USDC": Decimal("1")}
+        for token, price in current_prices.items():
+            if price is not None:
+                token_prices[token] = Decimal(str(price))
+
+        if not token_prices:
+            return Decimal("0")
+
+        values_sql = ", ".join(
+            f"(:token_{index}, :price_{index})"
+            for index in range(len(token_prices))
+        )
+        params = {"opened_status": Status.OPENED.value}
+        for index, (token, price) in enumerate(token_prices.items()):
+            params[f"token_{index}"] = token
+            params[f"price_{index}"] = price
+
+        query = text(
+            f"""
+            WITH token_prices(token_symbol, usdc_price) AS (
+                VALUES {values_sql}
+            )
+            SELECT COALESCE(
+                SUM(CAST(p.amount AS NUMERIC) * token_prices.usdc_price),
+                0
+            ) AS total_opened_amount_usdc
+            FROM "position" p
+            JOIN token_prices
+              ON token_prices.token_symbol = p.token_symbol
+            WHERE p.status = :opened_status
+            """
+        )
+
+        with self.Session() as db:
+            try:
+                total_amount = db.execute(query, params).scalar()
+                return Decimal(str(total_amount or 0))
+            except SQLAlchemyError as e:
+                logger.error("db_calc_open_amount_usdc_failed", error=str(e))
+                return Decimal("0")
 
     def save_current_price(self, position: Position, price_dict: dict) -> None:
         """

--- a/quantara/web_app/db/crud/position.py
+++ b/quantara/web_app/db/crud/position.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from typing import TypeVar
 from uuid import UUID
 
-from sqlalchemy import Numeric, cast, func, text
+from sqlalchemy import Column, Numeric, String, cast, func, values
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -363,34 +363,31 @@ class PositionDBConnector(UserDBConnector):
         if not token_prices:
             return Decimal("0")
 
-        values_sql = ", ".join(
-            f"(:token_{index}, :price_{index})"
-            for index in range(len(token_prices))
-        )
-        params = {"opened_status": Status.OPENED.value}
-        for index, (token, price) in enumerate(token_prices.items()):
-            params[f"token_{index}"] = token
-            params[f"price_{index}"] = price
-
-        query = text(
-            f"""
-            WITH token_prices(token_symbol, usdc_price) AS (
-                VALUES {values_sql}
-            )
-            SELECT COALESCE(
-                SUM(CAST(p.amount AS NUMERIC) * token_prices.usdc_price),
-                0
-            ) AS total_opened_amount_usdc
-            FROM "position" p
-            JOIN token_prices
-              ON token_prices.token_symbol = p.token_symbol
-            WHERE p.status = :opened_status
-            """
-        )
+        token_price_values = values(
+            Column("token_symbol", String),
+            Column("usdc_price", Numeric),
+            name="token_prices",
+        ).data(list(token_prices.items()))
 
         with self.Session() as db:
             try:
-                total_amount = db.execute(query, params).scalar()
+                total_amount = (
+                    db.query(
+                        func.coalesce(
+                            func.sum(
+                                cast(Position.amount, Numeric)
+                                * token_price_values.c.usdc_price
+                            ),
+                            0,
+                        )
+                    )
+                    .join(
+                        token_price_values,
+                        token_price_values.c.token_symbol == Position.token_symbol,
+                    )
+                    .filter(Position.status == Status.OPENED.value)
+                    .scalar()
+                )
                 return Decimal(str(total_amount or 0))
             except SQLAlchemyError as e:
                 logger.error("db_calc_open_amount_usdc_failed", error=str(e))

--- a/quantara/web_app/tasks/outbox_relay.py
+++ b/quantara/web_app/tasks/outbox_relay.py
@@ -12,12 +12,14 @@ from sqlalchemy.orm import Session
 from web_app.db.database import SessionLocal, init_db
 from web_app.db.models import OutboxEvent, Position, Status, Transaction, TransactionStatus
 from web_app.db.crud import PositionDBConnector, TransactionDBConnector
+from web_app.contract_tools.cache import delete_cache_key
 from web_app.contract_tools.mixins import DashboardMixin
 from web_app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+GET_STATS_CACHE_KEY = "stats:get_stats:v1"
 
 # Initialize the Celery application
 celery_app = Celery("outbox_relay", broker=REDIS_URL, backend=REDIS_URL)
@@ -85,6 +87,7 @@ def process_position_opened_task(self, event_id: str):
         # Update position status to OPENED if it's not already opened
         if position.status != Status.OPENED.value:
             position_db_connector.open_position(position_id, current_prices)
+            asyncio.run(delete_cache_key(GET_STATS_CACHE_KEY))
             logger.info("position_opened_successfully", position_id=position_id)
         else:
             logger.info("position_already_opened_skipping", position_id=position_id)

--- a/quantara/web_app/tests/test_get_stats_sql_cache_static.py
+++ b/quantara/web_app/tests/test_get_stats_sql_cache_static.py
@@ -22,10 +22,11 @@ class GetStatsSqlCacheStaticTests(unittest.TestCase):
         source = (CRUD_ROOT / "position.py").read_text()
 
         self.assertIn("def get_total_opened_amount_usdc", source)
-        self.assertIn("WITH token_prices(token_symbol, usdc_price) AS", source)
-        self.assertIn('FROM "position" p', source)
-        self.assertIn("SUM(CAST(p.amount AS NUMERIC) * token_prices.usdc_price)", source)
-        self.assertIn("WHERE p.status = :opened_status", source)
+        self.assertIn("values(", source)
+        self.assertIn('name="token_prices"', source)
+        self.assertIn("func.sum(", source)
+        self.assertIn("* token_price_values.c.usdc_price", source)
+        self.assertIn("Position.status == Status.OPENED.value", source)
         self.assertIn("Status.OPENED.value", source)
 
     def test_opened_and_closed_lifecycles_invalidate_stats_cache(self):

--- a/quantara/web_app/tests/test_get_stats_sql_cache_static.py
+++ b/quantara/web_app/tests/test_get_stats_sql_cache_static.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import unittest
+
+
+API_ROOT = Path(__file__).resolve().parents[1] / "api"
+CRUD_ROOT = Path(__file__).resolve().parents[1] / "db" / "crud"
+TASK_ROOT = Path(__file__).resolve().parents[1] / "tasks"
+CACHE_ROOT = Path(__file__).resolve().parents[1] / "contract_tools"
+
+
+class GetStatsSqlCacheStaticTests(unittest.TestCase):
+    def test_get_stats_uses_cached_sql_usdc_aggregate(self):
+        source = (API_ROOT / "user.py").read_text()
+
+        self.assertIn("GET_STATS_CACHE_TTL_SECONDS = 10", source)
+        self.assertIn("get_cached_or_fetch", source)
+        self.assertIn("GET_STATS_CACHE_KEY", source)
+        self.assertIn("get_total_opened_amount_usdc", source)
+        self.assertNotIn("get_total_amounts_for_open_positions()", source)
+
+    def test_position_connector_pushes_usdc_total_into_sql(self):
+        source = (CRUD_ROOT / "position.py").read_text()
+
+        self.assertIn("def get_total_opened_amount_usdc", source)
+        self.assertIn("WITH token_prices(token_symbol, usdc_price) AS", source)
+        self.assertIn('FROM "position" p', source)
+        self.assertIn("SUM(CAST(p.amount AS NUMERIC) * token_prices.usdc_price)", source)
+        self.assertIn("WHERE p.status = :opened_status", source)
+        self.assertIn("Status.OPENED.value", source)
+
+    def test_opened_and_closed_lifecycles_invalidate_stats_cache(self):
+        position_api = (API_ROOT / "position.py").read_text()
+        outbox_task = (TASK_ROOT / "outbox_relay.py").read_text()
+        cache_source = (CACHE_ROOT / "cache.py").read_text()
+
+        self.assertIn("async def delete_cache_key", cache_source)
+        self.assertIn("await delete_cache_key(GET_STATS_CACHE_KEY)", position_api)
+        self.assertIn("asyncio.run(delete_cache_key(GET_STATS_CACHE_KEY))", outbox_task)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #215.

Changes:
- adds a SQL-backed `get_total_opened_amount_usdc()` aggregate that joins opened positions to request-time token prices via a `VALUES` table and performs the USDC multiplication inside the database
- caches `/api/get_stats` for 10 seconds using the existing Redis cache helper
- adds best-effort cache key invalidation when positions are closed and when the outbox worker marks a position as opened
- adds static regression coverage for SQL aggregation, cache TTL/wiring, and lifecycle invalidation

Validation:
- parsed changed Python files with `ast.parse`
- did not run the full project test suite locally because that would require installing/executing project dependencies in this environment