### PR TITLE
fix(adapters): make register_adapters idempotent and add regression test

### DIFF
--- a/quantara/soroban/adapters/_register.py
+++ b/quantara/soroban/adapters/_register.py
@@ -9,9 +9,17 @@ from .soroswap_adapter import SoroswapAMMAdapter
 from .blend_adapter import BlendLendingAdapter
 
 
+_registered = False
+
+
 def register_adapters() -> None:
+    global _registered
+    if _registered:
+        return
+
     from .AMMAdapter import AMMAdapterFactory
     from .LendingAdapter import LendingAdapterFactory
 
     AMMAdapterFactory.register("soroswap", SoroswapAMMAdapter)
     LendingAdapterFactory.register("blend", BlendLendingAdapter)
+    _registered = True

--- a/quantara/soroban/tests/test_adapter_registration.py
+++ b/quantara/soroban/tests/test_adapter_registration.py
@@ -1,0 +1,17 @@
+"""Regression tests for adapter factory registration (issue #418)."""
+
+from quantara.soroban.adapters import AMMAdapterFactory, LendingAdapterFactory
+from quantara.soroban.adapters._register import register_adapters
+
+
+def test_amm_factory_has_soroswap():
+    assert "soroswap" in AMMAdapterFactory._adapters
+
+
+def test_lending_factory_has_blend():
+    assert "blend" in LendingAdapterFactory._adapters
+
+
+def test_register_adapters_is_idempotent():
+    register_adapters()
+    register_adapters()


### PR DESCRIPTION
## Description

Make `register_adapters()` idempotent by adding a `_registered` guard, and add a regression test asserting both factories are populated after import.

## Related Issue

Closes #418

## Change Type

- [x] fix — bug fix
- [x] test — adding or updating tests

## Testing Done

- Verified `AMMAdapterFactory._adapters` contains "soroswap" after import
- Verified `LendingAdapterFactory._adapters` contains "blend" after import
- Verified calling `register_adapters()` twice does not raise
- All 3 tests pass via `pytest soroban/tests/test_adapter_registration.py -v`

## Screenshots (if UI changes)

None

## Environment Variables

None

## Checklist

- [x] `make lint` passes (pylint on changed `.py` files)
- [x] `make test` passes (pytest in `quantara/web_app/tests/`)
- [x] CI is green on this PR
- [x] Documentation updated (if applicable)
- [x] PR is linked to a related issue (`Closes #418`)